### PR TITLE
add display info API and T key dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
     PLATFORM_SRC = src/platform/platform_macos.m
-    LDFLAGS      = -framework Cocoa
+    LDFLAGS      = -framework Cocoa -framework IOKit
     OBJCFLAGS    = -fobjc-arc
 endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -125,6 +125,49 @@ static void render_checkerboard(platform_framebuffer_t *fb) {
     }
 }
 
+static const char *connection_type_str(platform_connection_type_t t) {
+    switch (t) {
+        case PLATFORM_CONNECTION_INTERNAL:    return "Internal";
+        case PLATFORM_CONNECTION_HDMI:        return "HDMI";
+        case PLATFORM_CONNECTION_DISPLAYPORT: return "DisplayPort";
+        case PLATFORM_CONNECTION_THUNDERBOLT: return "Thunderbolt";
+        case PLATFORM_CONNECTION_AIRPLAY:     return "AirPlay";
+        case PLATFORM_CONNECTION_VGA:         return "VGA";
+        case PLATFORM_CONNECTION_DVI:         return "DVI";
+        default:                              return "Unknown";
+    }
+}
+
+static void print_display(int idx, const platform_display_info_t *d, bool is_window) {
+    printf("  [%d]%s %-32s  id=%u scale=%.1f main=%d builtin=%d online=%d\n",
+           idx, is_window ? " *" : "  ", d->name,
+           d->id, (double)d->scale, d->is_main, d->builtin, d->is_online);
+    if (d->name_original[0])
+        printf("       original=\"%s\"\n", d->name_original);
+    printf("       bounds=(%d,%d)+(%dx%dpt)  work=(%d,%d)+(%dx%dpt)  pixels=%dx%d  size=%dx%dmm\n",
+           d->bounds_x, d->bounds_y, d->bounds_w, d->bounds_h,
+           d->work_x, d->work_y, d->work_w, d->work_h,
+           d->pixels_w, d->pixels_h, d->size_mm_w, d->size_mm_h);
+    printf("       refresh=%.2fHz  rotation=%d°%s  conn=%s%s\n",
+           (double)d->refresh_hz, d->rotation,
+           d->rotation_supported ? " (rotatable)" : "",
+           connection_type_str(d->connection_type),
+           d->mirrors_id ? "  (mirrors another)" : "");
+}
+
+static void print_displays_with_framebuffer(void) {
+    platform_framebuffer_t *fb = platform_get_framebuffer();
+    printf("framebuffer: %dx%d\n", fb->width, fb->height);
+
+    platform_display_info_t displays[8];
+    int n = platform_get_displays(displays, 8);
+    uint32_t my = platform_get_window_display_id();
+    printf("displays: %d\n", n);
+    for (int i = 0; i < n; i++) {
+        print_display(i, &displays[i], displays[i].id == my);
+    }
+}
+
 int main(void) {
     if (!platform_init(1280, 720, "libcg")) {
         fprintf(stderr, "Failed to initialize platform\n");
@@ -207,10 +250,7 @@ int main(void) {
                 bg_checkerboard = !bg_checkerboard;
                 printf("background: %s\n", bg_checkerboard ? "checkerboard" : "transparent");
             }
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_T)) {
-                platform_framebuffer_t *fbi = platform_get_framebuffer();
-                printf("framebuffer: %dx%d\n", fbi->width, fbi->height);
-            }
+            if (platform_is_key_pressed(&input, PLATFORM_KEY_T)) print_displays_with_framebuffer();
         }
 
         /* Mouse output is suppressed while typing a color */

--- a/src/main.c
+++ b/src/main.c
@@ -155,6 +155,89 @@ static void print_display(int idx, const platform_display_info_t *d, bool is_win
            d->mirrors_id ? "  (mirrors another)" : "");
 }
 
+/* One row per distinct pixel resolution (collapses HiDPI variants),
+   integer refresh rates ≥ 60Hz only (drops video rates like 47.95/48/50/59.94),
+   sorted by area ascending. Shaped like a game's resolution dropdown. */
+static void print_window_display_modes(void) {
+    typedef struct {
+        int  pw, ph;
+        int  rates[8];     /* unique integer rates, sorted desc */
+        int  rate_count;
+        bool has_current;
+        int  current_rate;
+    } group_t;
+
+    uint32_t my = platform_get_window_display_id();
+    platform_video_mode_t modes[128];
+    int n = platform_get_display_modes(my, modes, 128);
+
+    group_t groups[16];
+    int gc = 0;
+    for (int i = 0; i < n; i++) {
+        int rate = (int)(modes[i].refresh_hz + 0.5f);
+        if (rate < 60) continue;  /* drop 24/30/48/50/etc — video cadences */
+
+        /* find or add group keyed on pixel resolution */
+        int gi = -1;
+        for (int j = 0; j < gc; j++) {
+            if (groups[j].pw == modes[i].pixels_w && groups[j].ph == modes[i].pixels_h) {
+                gi = j; break;
+            }
+        }
+        if (gi < 0 && gc < 16) {
+            gi = gc++;
+            groups[gi].pw = modes[i].pixels_w;
+            groups[gi].ph = modes[i].pixels_h;
+            groups[gi].rate_count = 0;
+            groups[gi].has_current = false;
+        }
+        if (gi < 0) continue;
+
+        /* insert rate sorted desc, dedup */
+        group_t *g = &groups[gi];
+        bool seen = false;
+        for (int r = 0; r < g->rate_count; r++) {
+            if (g->rates[r] == rate) { seen = true; break; }
+        }
+        if (!seen && g->rate_count < 8) {
+            int pos = g->rate_count;
+            while (pos > 0 && g->rates[pos-1] < rate) { g->rates[pos] = g->rates[pos-1]; pos--; }
+            g->rates[pos] = rate;
+            g->rate_count++;
+        }
+        if (modes[i].is_current) {
+            g->has_current = true;
+            g->current_rate = rate;
+        }
+    }
+
+    /* sort groups by pixel area ascending */
+    for (int i = 1; i < gc; i++) {
+        group_t tmp = groups[i];
+        int j = i;
+        while (j > 0 && (long long)groups[j-1].pw * groups[j-1].ph > (long long)tmp.pw * tmp.ph) {
+            groups[j] = groups[j-1]; j--;
+        }
+        groups[j] = tmp;
+    }
+
+    printf("modes for display id=%u: %d total, %d resolutions\n", my, n, gc);
+    for (int i = 0; i < gc; i++) {
+        group_t *g = &groups[i];
+        char rates[64] = {0};
+        size_t off = 0;
+        for (int r = 0; r < g->rate_count; r++) {
+            int wrote = snprintf(rates + off, sizeof(rates) - off,
+                                 "%s%d", r == 0 ? "" : "/", g->rates[r]);
+            if (wrote > 0 && (size_t)wrote < sizeof(rates) - off) off += (size_t)wrote;
+        }
+        if (g->has_current)
+            printf("  %4dx%-4d  %sHz  ← current @ %dHz\n", g->pw, g->ph, rates, g->current_rate);
+        else
+            printf("  %4dx%-4d  %sHz\n", g->pw, g->ph, rates);
+    }
+}
+
 static void print_displays_with_framebuffer(void) {
     platform_framebuffer_t *fb = platform_get_framebuffer();
     printf("framebuffer: %dx%d\n", fb->width, fb->height);
@@ -251,6 +334,7 @@ int main(void) {
                 printf("background: %s\n", bg_checkerboard ? "checkerboard" : "transparent");
             }
             if (platform_is_key_pressed(&input, PLATFORM_KEY_T)) print_displays_with_framebuffer();
+            if (platform_is_key_pressed(&input, PLATFORM_KEY_L)) print_window_display_modes();
         }
 
         /* Mouse output is suppressed while typing a color */

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -167,6 +167,16 @@ typedef struct {
 /* Returns number of displays; fills up to `max` entries in out[] */
 int platform_get_displays(platform_display_info_t *out, int max);
 
+typedef struct {
+    int   width, height;         /* logical points */
+    int   pixels_w, pixels_h;    /* physical pixels */
+    float refresh_hz;
+    bool  is_current;            /* mode currently active for this display */
+} platform_video_mode_t;
+
+/* Returns number of modes for the given display; fills up to `max` entries */
+int platform_get_display_modes(uint32_t display_id, platform_video_mode_t *out, int max);
+
 /* CGDirectDisplayID of the display the window is currently on; match against
    platform_display_info_t.id from platform_get_displays. */
 uint32_t platform_get_window_display_id(void);

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -115,4 +115,60 @@ platform_framebuffer_t *platform_get_framebuffer(void);
 void platform_toggle_fullscreen(void);
 bool platform_is_fullscreen(void);
 
+/* Display info */
+
+typedef enum {
+    PLATFORM_CONNECTION_UNKNOWN = 0,
+    PLATFORM_CONNECTION_INTERNAL,
+    PLATFORM_CONNECTION_HDMI,
+    PLATFORM_CONNECTION_DISPLAYPORT,
+    PLATFORM_CONNECTION_THUNDERBOLT,
+    PLATFORM_CONNECTION_VGA,
+    PLATFORM_CONNECTION_DVI,
+    PLATFORM_CONNECTION_AIRPLAY,
+} platform_connection_type_t;
+
+typedef struct {
+    char     name[64];           /* localizedName — user-rename if set, else EDID, else "Built-in Retina Display" */
+    char     name_original[64];  /* raw EDID name; empty for built-in or unavailable */
+
+    uint32_t id;                 /* CGDirectDisplayID */
+    float    scale;              /* backingScaleFactor (1.0, 2.0) */
+
+    int      bounds_x;           /* global display origin in logical points */
+    int      bounds_y;
+    int      bounds_w;           /* logical points */
+    int      bounds_h;
+
+    int      work_x;             /* visibleFrame — bounds minus menu bar / dock */
+    int      work_y;
+    int      work_w;
+    int      work_h;
+
+    int      pixels_w;           /* physical pixels of current display mode */
+    int      pixels_h;
+
+    int      size_mm_w;          /* panel physical size in mm; 0 if unknown */
+    int      size_mm_h;
+
+    float    refresh_hz;         /* 0.0 if variable / unavailable (ProMotion) */
+
+    bool     builtin;            /* CGDisplayIsBuiltin */
+    bool     is_main;            /* CGDisplayIsMain — system primary */
+    bool     is_online;          /* CGDisplayIsOnline */
+    bool     rotation_supported; /* IOFramebuffer kIOFBRotateMask has bits beyond 0° */
+
+    uint32_t mirrors_id;         /* CGDisplayMirrorsDisplay — id mirrored, 0 if not mirroring */
+    int      rotation;           /* 0/90/180/270 (CGDisplayRotation) */
+
+    platform_connection_type_t connection_type;
+} platform_display_info_t;
+
+/* Returns number of displays; fills up to `max` entries in out[] */
+int platform_get_displays(platform_display_info_t *out, int max);
+
+/* CGDirectDisplayID of the display the window is currently on; match against
+   platform_display_info_t.id from platform_get_displays. */
+uint32_t platform_get_window_display_id(void);
+
 #endif /* PLATFORM_H */

--- a/src/platform/platform_macos.m
+++ b/src/platform/platform_macos.m
@@ -1,5 +1,8 @@
 #include "platform.h"
 #import <Cocoa/Cocoa.h>
+#import <IOKit/graphics/IOGraphicsLib.h>
+#import <IOKit/IOKitLib.h>
+#include <string.h>
 
 /* --- Private types (needed by the public API signatures) --- */
 typedef struct {
@@ -326,6 +329,14 @@ platform_framebuffer_t *platform_get_framebuffer(void) {
     reallocate_framebuffer();
 }
 
+// Fires when the window crosses to a different display. Same-scale moves
+// don't fire backingProperties; reallocate defensively (idempotent if size
+// hasn't changed).
+- (void)windowDidChangeScreen:(NSNotification *)notification {
+    (void)notification;
+    reallocate_framebuffer();
+}
+
 @end
 
 /* --- Private helpers --- */
@@ -471,4 +482,228 @@ void platform_toggle_fullscreen(void) {
 
 bool platform_is_fullscreen(void) {
     return ([state.ns_window styleMask] & NSWindowStyleMaskFullScreen) != 0;
+}
+
+/* --- Display info --- */
+
+// Find the IODisplayConnect IOService matching a CGDirectDisplayID by
+// comparing vendor/product/serial. Returns 0 if no match. Caller must
+// IOObjectRelease() the result if non-zero.
+static io_service_t io_service_for_display(CGDirectDisplayID display) {
+    io_iterator_t iter;
+    if (IOServiceGetMatchingServices(kIOMainPortDefault,
+                                     IOServiceMatching("IODisplayConnect"),
+                                     &iter) != kIOReturnSuccess) {
+        return 0;
+    }
+
+    uint32_t want_v = CGDisplayVendorNumber(display);
+    uint32_t want_p = CGDisplayModelNumber(display);
+    uint32_t want_s = CGDisplaySerialNumber(display);
+
+    io_service_t result = 0;
+    io_service_t serv;
+    while ((serv = IOIteratorNext(iter)) != 0) {
+        CFDictionaryRef info = IODisplayCreateInfoDictionary(serv, 0);
+        if (info) {
+            uint32_t v = 0, p = 0, s = 0;
+            CFNumberRef vn = CFDictionaryGetValue(info, CFSTR(kDisplayVendorID));
+            CFNumberRef pn = CFDictionaryGetValue(info, CFSTR(kDisplayProductID));
+            CFNumberRef sn = CFDictionaryGetValue(info, CFSTR(kDisplaySerialNumber));
+            if (vn) CFNumberGetValue(vn, kCFNumberSInt32Type, &v);
+            if (pn) CFNumberGetValue(pn, kCFNumberSInt32Type, &p);
+            if (sn) CFNumberGetValue(sn, kCFNumberSInt32Type, &s);
+            CFRelease(info);
+
+            if (v == want_v && p == want_p && s == want_s) {
+                result = serv;
+                break;
+            }
+        }
+        IOObjectRelease(serv);
+    }
+    IOObjectRelease(iter);
+    return result;
+}
+
+// Read raw EDID name from IODisplayConnect. The DisplayProductName key holds
+// a per-language NSDictionary; we pick user's preferred language, then "en",
+// then any. Empty out[] if no name is available (typical for built-in panels).
+static void fill_edid_name(io_service_t serv, char *out, size_t cap) {
+    out[0] = '\0';
+    if (!serv) return;
+
+    CFDictionaryRef info = IODisplayCreateInfoDictionary(serv, 0);
+    if (!info) return;
+
+    CFDictionaryRef names = CFDictionaryGetValue(info, CFSTR(kDisplayProductName));
+    if (!names || CFGetTypeID(names) != CFDictionaryGetTypeID() || CFDictionaryGetCount(names) == 0) {
+        CFRelease(info);
+        return;
+    }
+
+    CFStringRef name_str = NULL;
+    NSArray *langs = [NSLocale preferredLanguages];
+    if ([langs count] > 0) {
+        name_str = CFDictionaryGetValue(names, (__bridge CFStringRef)langs[0]);
+    }
+    if (!name_str) name_str = CFDictionaryGetValue(names, CFSTR("en"));
+    if (!name_str) {
+        CFIndex count = CFDictionaryGetCount(names);
+        if (count > 0) {
+            const void **values = (const void **)malloc(sizeof(void *) * (size_t)count);
+            CFDictionaryGetKeysAndValues(names, NULL, values);
+            name_str = (CFStringRef)values[0];
+            free(values);
+        }
+    }
+
+    if (name_str && CFGetTypeID(name_str) == CFStringGetTypeID()) {
+        CFStringGetCString(name_str, out, (CFIndex)cap, kCFStringEncodingUTF8);
+    }
+    CFRelease(info);
+}
+
+// IOFramebuffer (parent of IODisplayConnect) has the rotate-mask property.
+// Bit 0 is always 0° (identity); >1 means at least one other rotation works.
+static bool query_rotation_supported(io_service_t serv) {
+    if (!serv) return false;
+
+    io_service_t parent = 0;
+    if (IORegistryEntryGetParentEntry(serv, kIOServicePlane, &parent) != kIOReturnSuccess) {
+        return false;
+    }
+
+    bool supported = false;
+    CFNumberRef rot = (CFNumberRef)IORegistryEntryCreateCFProperty(
+        parent, CFSTR("rotate-mask"), kCFAllocatorDefault, 0);
+    if (rot && CFGetTypeID(rot) == CFNumberGetTypeID()) {
+        uint32_t mask = 0;
+        CFNumberGetValue(rot, kCFNumberSInt32Type, &mask);
+        supported = mask > 1;
+    }
+    if (rot) CFRelease(rot);
+    IOObjectRelease(parent);
+    return supported;
+}
+
+// Walk parent chain looking for a class name that identifies the connection.
+// Built-in is detected upfront via CGDisplayIsBuiltin and short-circuits here.
+static platform_connection_type_t detect_connection_type(io_service_t serv, bool builtin) {
+    if (builtin) return PLATFORM_CONNECTION_INTERNAL;
+    if (!serv)   return PLATFORM_CONNECTION_UNKNOWN;
+
+    io_service_t s = serv;
+    IOObjectRetain(s);
+    platform_connection_type_t result = PLATFORM_CONNECTION_UNKNOWN;
+    for (int i = 0; i < 8; i++) {
+        io_name_t class_name;
+        if (IOObjectGetClass(s, class_name) == kIOReturnSuccess) {
+            if      (strstr(class_name, "HDMI"))        { result = PLATFORM_CONNECTION_HDMI;        break; }
+            else if (strstr(class_name, "DisplayPort")) { result = PLATFORM_CONNECTION_DISPLAYPORT; break; }
+            else if (strstr(class_name, "Thunderbolt")) { result = PLATFORM_CONNECTION_THUNDERBOLT; break; }
+            else if (strstr(class_name, "AirPlay"))     { result = PLATFORM_CONNECTION_AIRPLAY;     break; }
+            else if (strstr(class_name, "VGA"))         { result = PLATFORM_CONNECTION_VGA;         break; }
+            else if (strstr(class_name, "DVI"))         { result = PLATFORM_CONNECTION_DVI;         break; }
+        }
+        io_service_t parent = 0;
+        if (IORegistryEntryGetParentEntry(s, kIOServicePlane, &parent) != kIOReturnSuccess) {
+            break;
+        }
+        IOObjectRelease(s);
+        s = parent;
+    }
+    IOObjectRelease(s);
+    return result;
+}
+
+static NSScreen *screen_for_display(CGDirectDisplayID display) {
+    for (NSScreen *s in [NSScreen screens]) {
+        NSNumber *num = [s deviceDescription][@"NSScreenNumber"];
+        if (num && (CGDirectDisplayID)[num unsignedIntValue] == display) {
+            return s;
+        }
+    }
+    return nil;
+}
+
+static void fill_display_info(CGDirectDisplayID id, platform_display_info_t *out) {
+    memset(out, 0, sizeof(*out));
+    out->id = id;
+
+    NSScreen *screen = screen_for_display(id);
+    if (screen) {
+        const char *cstr = [[screen localizedName] UTF8String];
+        if (cstr) strncpy(out->name, cstr, sizeof(out->name) - 1);
+
+        out->scale = (float)[screen backingScaleFactor];
+
+        NSRect frame = [screen frame];
+        out->bounds_x = (int)frame.origin.x;
+        out->bounds_y = (int)frame.origin.y;
+        out->bounds_w = (int)frame.size.width;
+        out->bounds_h = (int)frame.size.height;
+
+        NSRect work = [screen visibleFrame];
+        out->work_x = (int)work.origin.x;
+        out->work_y = (int)work.origin.y;
+        out->work_w = (int)work.size.width;
+        out->work_h = (int)work.size.height;
+
+        out->refresh_hz = (float)[screen maximumFramesPerSecond];
+    } else {
+        CGRect b = CGDisplayBounds(id);
+        out->bounds_x = (int)b.origin.x;
+        out->bounds_y = (int)b.origin.y;
+        out->bounds_w = (int)b.size.width;
+        out->bounds_h = (int)b.size.height;
+        out->scale    = 1.0f;
+    }
+
+    out->pixels_w   = (int)CGDisplayPixelsWide(id);
+    out->pixels_h   = (int)CGDisplayPixelsHigh(id);
+
+    CGSize mm = CGDisplayScreenSize(id);
+    out->size_mm_w  = (int)mm.width;
+    out->size_mm_h  = (int)mm.height;
+
+    out->builtin    = CGDisplayIsBuiltin(id) ? true : false;
+    out->is_main    = CGDisplayIsMain(id)    ? true : false;
+    out->is_online  = CGDisplayIsOnline(id)  ? true : false;
+    out->mirrors_id = (uint32_t)CGDisplayMirrorsDisplay(id);
+    out->rotation   = (int)CGDisplayRotation(id);
+
+    // Prefer mode's reported refresh if it's nonzero (more precise than
+    // NSScreen's int Hz). 0 from the mode means built-in / variable.
+    CGDisplayModeRef mode = CGDisplayCopyDisplayMode(id);
+    if (mode) {
+        double hz = CGDisplayModeGetRefreshRate(mode);
+        if (hz > 0.0) out->refresh_hz = (float)hz;
+        CGDisplayModeRelease(mode);
+    }
+
+    io_service_t serv = io_service_for_display(id);
+    fill_edid_name(serv, out->name_original, sizeof(out->name_original));
+    out->rotation_supported = query_rotation_supported(serv);
+    out->connection_type    = detect_connection_type(serv, out->builtin);
+    if (serv) IOObjectRelease(serv);
+}
+
+int platform_get_displays(platform_display_info_t *out, int max) {
+    if (max <= 0) return 0;
+    CGDirectDisplayID ids[16];
+    uint32_t count = 0;
+    if (CGGetActiveDisplayList(16, ids, &count) != kCGErrorSuccess) return 0;
+    int n = (int)count < max ? (int)count : max;
+    for (int i = 0; i < n; i++) {
+        fill_display_info(ids[i], &out[i]);
+    }
+    return n;
+}
+
+uint32_t platform_get_window_display_id(void) {
+    NSScreen *screen = [state.ns_window screen];
+    if (!screen) screen = [NSScreen mainScreen];
+    NSNumber *num = [screen deviceDescription][@"NSScreenNumber"];
+    return num ? (uint32_t)[num unsignedIntValue] : 0;
 }

--- a/src/platform/platform_macos.m
+++ b/src/platform/platform_macos.m
@@ -701,6 +701,46 @@ int platform_get_displays(platform_display_info_t *out, int max) {
     return n;
 }
 
+int platform_get_display_modes(uint32_t display_id, platform_video_mode_t *out, int max) {
+    if (max <= 0) return 0;
+    CFArrayRef modes = CGDisplayCopyAllDisplayModes((CGDirectDisplayID)display_id, NULL);
+    if (!modes) return 0;
+
+    CGDisplayModeRef cur = CGDisplayCopyDisplayMode((CGDirectDisplayID)display_id);
+    int32_t cur_id = cur ? (int32_t)CGDisplayModeGetIODisplayModeID(cur) : -1;
+
+    CFIndex count = CFArrayGetCount(modes);
+    int n = (int)count < max ? (int)count : max;
+    bool found_current = false;
+    for (int i = 0; i < n; i++) {
+        CGDisplayModeRef m = (CGDisplayModeRef)CFArrayGetValueAtIndex(modes, i);
+        out[i].width      = (int)CGDisplayModeGetWidth(m);
+        out[i].height     = (int)CGDisplayModeGetHeight(m);
+        out[i].pixels_w   = (int)CGDisplayModeGetPixelWidth(m);
+        out[i].pixels_h   = (int)CGDisplayModeGetPixelHeight(m);
+        out[i].refresh_hz = (float)CGDisplayModeGetRefreshRate(m);
+        out[i].is_current = ((int32_t)CGDisplayModeGetIODisplayModeID(m) == cur_id);
+        if (out[i].is_current) found_current = true;
+    }
+
+    /* CGDisplayCopyAllDisplayModes(NULL) hides scaled HiDPI modes. If the
+       user is on one of those, the current mode is missing from the array —
+       append it so callers always see a row marked is_current. */
+    if (cur && !found_current && n < max) {
+        out[n].width      = (int)CGDisplayModeGetWidth(cur);
+        out[n].height     = (int)CGDisplayModeGetHeight(cur);
+        out[n].pixels_w   = (int)CGDisplayModeGetPixelWidth(cur);
+        out[n].pixels_h   = (int)CGDisplayModeGetPixelHeight(cur);
+        out[n].refresh_hz = (float)CGDisplayModeGetRefreshRate(cur);
+        out[n].is_current = true;
+        n++;
+    }
+
+    if (cur) CGDisplayModeRelease(cur);
+    CFRelease(modes);
+    return n;
+}
+
 uint32_t platform_get_window_display_id(void) {
     NSScreen *screen = [state.ns_window screen];
     if (!screen) screen = [NSScreen mainScreen];


### PR DESCRIPTION
T key now prints the framebuffer dims plus full info for every connected
display, marking the one the window is on. Each entry includes:
  name + raw EDID name, id, scale, bounds, work area (visibleFrame),
  pixel resolution, panel size in mm, refresh, rotation + capability,
  connection type (Internal/HDMI/DisplayPort/Thunderbolt/AirPlay), and
  whether it's the system main / mirroring another display.

Adds windowDidChangeScreen: handler so the framebuffer is reallocated
when the window crosses to a same-scale display (backingProperties
doesn't fire in that case).

IOKit walk extracts the raw EDID name, kIOFBRotateMask for rotation
capability, and parent class scan for connection type. Requires linking
-framework IOKit.