### PR TITLE
implement platform_run + invert main loop

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -251,136 +251,133 @@ static void print_displays_with_framebuffer(void) {
     }
 }
 
+static void on_frame(const platform_frame_t *f, void *ud) {
+    (void)ud;
+
+    /* All loop-local state lives here as statics. PR 2.4 will clean these
+       into a proper game_state_t once event-based input lands. */
+    static bool print_mouse_coords = false;
+    static bool bg_checkerboard    = false;
+    static int  last_mx = -1, last_my = -1;
+    static pattern_t pattern = PATTERN_SOLID;
+    static bool color_input_mode = false;
+    static char color_input_buf[16] = {0};
+    static int  color_input_len = 0;
+    static platform_input_t input = {0};
+
+    platform_poll_events(&input);
+
+    /* Process text input — may toggle color_input_mode */
+    for (int i = 0; i < input.text_len; i++) {
+        char c = input.text[i];
+        if (!color_input_mode && c == '#') {
+            color_input_mode = true;
+            color_input_len  = 0;
+            color_input_buf[0] = '\0';
+            printf("color input mode (type hex digits, Enter to apply, Esc to cancel)\n");
+            printf("color input: #");
+            fflush(stdout);
+        } else if (color_input_mode && c != '#' && hex_digit(c) >= 0 && color_input_len < 8) {
+            color_input_buf[color_input_len++] = c;
+            color_input_buf[color_input_len]   = '\0';
+            printf("\r\x1b[Kcolor input: #%s", color_input_buf);
+            fflush(stdout);
+        }
+    }
+
+    if (color_input_mode) {
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_BACKSPACE) && color_input_len > 0) {
+            color_input_buf[--color_input_len] = '\0';
+            printf("\r\x1b[Kcolor input: #%s", color_input_buf);
+            fflush(stdout);
+        }
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_ENTER)) {
+            u32 parsed;
+            if (parse_hex_color(color_input_buf, color_input_len, &parsed)) {
+                s_custom_color = parsed;
+                pattern = PATTERN_CUSTOM_COLOR;
+                printf("\ncolor applied: #%s -> 0x%08X\n", color_input_buf, parsed);
+            } else {
+                printf("\r\x1b[K#%s is not valid format\n", color_input_buf);
+            }
+            color_input_mode = false;
+            color_input_len  = 0;
+            color_input_buf[0] = '\0';
+        }
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_ESCAPE)) {
+            printf("\ncolor input cancelled\n");
+            color_input_mode = false;
+            color_input_len  = 0;
+            color_input_buf[0] = '\0';
+        }
+    } else {
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_Q))
+            platform_request_quit();
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_M)) {
+            print_mouse_coords = !print_mouse_coords;
+            printf("mouse coord printing: %s\n", print_mouse_coords ? "ON" : "OFF");
+        }
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_F))
+            platform_toggle_fullscreen();
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_ESCAPE) && platform_is_fullscreen())
+            platform_toggle_fullscreen();
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_1)) pattern = PATTERN_SOLID;
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_2)) pattern = PATTERN_GRADIENT;
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_3)) pattern = PATTERN_CYCLE;
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_4)) pattern = PATTERN_NOISE;
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_B)) {
+            bg_checkerboard = !bg_checkerboard;
+            printf("background: %s\n", bg_checkerboard ? "checkerboard" : "transparent");
+        }
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_T)) print_displays_with_framebuffer();
+        if (platform_is_key_pressed(&input, PLATFORM_KEY_L)) print_window_display_modes();
+    }
+
+    /* Mouse output is suppressed while typing a color */
+    if (!color_input_mode) {
+        if (print_mouse_coords && (input.mouse.x != last_mx || input.mouse.y != last_my)) {
+            printf("mouse: (%d, %d)\n", input.mouse.x, input.mouse.y);
+            last_mx = input.mouse.x;
+            last_my = input.mouse.y;
+        }
+        if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_LEFT))
+            printf("mouse left pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
+        if (platform_is_mouse_released(&input, PLATFORM_MOUSE_LEFT))
+            printf("mouse left released at (%d, %d)\n", input.mouse.x, input.mouse.y);
+        if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_RIGHT))
+            printf("mouse right pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
+        if (platform_is_mouse_released(&input, PLATFORM_MOUSE_RIGHT))
+            printf("mouse right released at (%d, %d)\n", input.mouse.x, input.mouse.y);
+        if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_MIDDLE))
+            printf("mouse middle pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
+        if (platform_is_mouse_released(&input, PLATFORM_MOUSE_MIDDLE))
+            printf("mouse middle released at (%d, %d)\n", input.mouse.x, input.mouse.y);
+        if (input.mouse.scroll_dx != 0.0f || input.mouse.scroll_dy != 0.0f)
+            printf("scroll: dx=%.1f dy=%.1f\n", (double)input.mouse.scroll_dx, (double)input.mouse.scroll_dy);
+    }
+
+    /* Background first — either checker or fully transparent.
+       Required so alpha-blended patterns (CUSTOM_COLOR) have a
+       correct base and don't pick up last frame's pixels. */
+    if (bg_checkerboard) {
+        render_checkerboard(f->fb);
+    } else {
+        framebuffer_clear(f->fb, 0x00000000);
+    }
+    switch (pattern) {
+        case PATTERN_SOLID:        render_solid(f->fb); break;
+        case PATTERN_GRADIENT:     render_gradient(f->fb); break;
+        case PATTERN_CYCLE:        render_cycle(f->fb, (double)f->frame_index * 0.05); break;
+        case PATTERN_NOISE:        render_noise(f->fb); break;
+        case PATTERN_CUSTOM_COLOR: render_custom_color(f->fb, s_custom_color); break;
+    }
+}
+
 int main(void) {
-    if (!platform_init(1280, 720, "libcg")) {
-        fprintf(stderr, "Failed to initialize platform\n");
-        return 1;
-    }
-
-    bool print_mouse_coords = false;
-    bool bg_checkerboard    = false;
-    int  last_mx = -1, last_my = -1;
-    pattern_t pattern = PATTERN_SOLID;
-    int  frame_count = 0;
-
-    bool color_input_mode = false;
-    char color_input_buf[16] = {0};
-    int  color_input_len = 0;
-
-    platform_input_t input = {0};
-    while (!input.quit_requested) {
-        platform_poll_events(&input);
-
-        /* Process text input — may toggle color_input_mode */
-        for (int i = 0; i < input.text_len; i++) {
-            char c = input.text[i];
-            if (!color_input_mode && c == '#') {
-                color_input_mode = true;
-                color_input_len  = 0;
-                color_input_buf[0] = '\0';
-                printf("color input mode (type hex digits, Enter to apply, Esc to cancel)\n");
-                printf("color input: #");
-                fflush(stdout);
-            } else if (color_input_mode && c != '#' && hex_digit(c) >= 0 && color_input_len < 8) {
-                color_input_buf[color_input_len++] = c;
-                color_input_buf[color_input_len]   = '\0';
-                printf("\r\x1b[Kcolor input: #%s", color_input_buf);
-                fflush(stdout);
-            }
-        }
-
-        if (color_input_mode) {
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_BACKSPACE) && color_input_len > 0) {
-                color_input_buf[--color_input_len] = '\0';
-                printf("\r\x1b[Kcolor input: #%s", color_input_buf);
-                fflush(stdout);
-            }
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_ENTER)) {
-                u32 parsed;
-                if (parse_hex_color(color_input_buf, color_input_len, &parsed)) {
-                    s_custom_color = parsed;
-                    pattern = PATTERN_CUSTOM_COLOR;
-                    printf("\ncolor applied: #%s -> 0x%08X\n", color_input_buf, parsed);
-                } else {
-                    printf("\r\x1b[K#%s is not valid format\n", color_input_buf);
-                }
-                color_input_mode = false;
-                color_input_len  = 0;
-                color_input_buf[0] = '\0';
-            }
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_ESCAPE)) {
-                printf("\ncolor input cancelled\n");
-                color_input_mode = false;
-                color_input_len  = 0;
-                color_input_buf[0] = '\0';
-            }
-        } else {
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_Q))
-                input.quit_requested = true;
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_M)) {
-                print_mouse_coords = !print_mouse_coords;
-                printf("mouse coord printing: %s\n", print_mouse_coords ? "ON" : "OFF");
-            }
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_F))
-                platform_toggle_fullscreen();
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_ESCAPE) && platform_is_fullscreen())
-                platform_toggle_fullscreen();
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_1)) pattern = PATTERN_SOLID;
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_2)) pattern = PATTERN_GRADIENT;
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_3)) pattern = PATTERN_CYCLE;
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_4)) pattern = PATTERN_NOISE;
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_B)) {
-                bg_checkerboard = !bg_checkerboard;
-                printf("background: %s\n", bg_checkerboard ? "checkerboard" : "transparent");
-            }
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_T)) print_displays_with_framebuffer();
-            if (platform_is_key_pressed(&input, PLATFORM_KEY_L)) print_window_display_modes();
-        }
-
-        /* Mouse output is suppressed while typing a color */
-        if (!color_input_mode) {
-            if (print_mouse_coords && (input.mouse.x != last_mx || input.mouse.y != last_my)) {
-                printf("mouse: (%d, %d)\n", input.mouse.x, input.mouse.y);
-                last_mx = input.mouse.x;
-                last_my = input.mouse.y;
-            }
-            if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_LEFT))
-                printf("mouse left pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
-            if (platform_is_mouse_released(&input, PLATFORM_MOUSE_LEFT))
-                printf("mouse left released at (%d, %d)\n", input.mouse.x, input.mouse.y);
-            if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_RIGHT))
-                printf("mouse right pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
-            if (platform_is_mouse_released(&input, PLATFORM_MOUSE_RIGHT))
-                printf("mouse right released at (%d, %d)\n", input.mouse.x, input.mouse.y);
-            if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_MIDDLE))
-                printf("mouse middle pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
-            if (platform_is_mouse_released(&input, PLATFORM_MOUSE_MIDDLE))
-                printf("mouse middle released at (%d, %d)\n", input.mouse.x, input.mouse.y);
-            if (input.mouse.scroll_dx != 0.0f || input.mouse.scroll_dy != 0.0f)
-                printf("scroll: dx=%.1f dy=%.1f\n", (double)input.mouse.scroll_dx, (double)input.mouse.scroll_dy);
-        }
-
-        platform_framebuffer_t *fb = platform_get_framebuffer();
-        /* Background first — either checker or fully transparent.
-           Required so alpha-blended patterns (CUSTOM_COLOR) have a
-           correct base and don't pick up last frame's pixels. */
-        if (bg_checkerboard) {
-            render_checkerboard(fb);
-        } else {
-            framebuffer_clear(fb, 0x00000000);
-        }
-        switch (pattern) {
-            case PATTERN_SOLID:        render_solid(fb); break;
-            case PATTERN_GRADIENT:     render_gradient(fb); break;
-            case PATTERN_CYCLE:        render_cycle(fb, frame_count * 0.05); break;
-            case PATTERN_NOISE:        render_noise(fb); break;
-            case PATTERN_CUSTOM_COLOR: render_custom_color(fb, s_custom_color); break;
-        }
-
-        frame_count++;
-        platform_present();
-    }
-
-    platform_shutdown();
-    return 0;
+    return platform_run(&(platform_app_desc_t){
+        .width    = 1280,
+        .height   = 720,
+        .title    = "libcg",
+        .frame_cb = on_frame,
+    });
 }

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -266,13 +266,18 @@ typedef struct {
 } platform_frame_t;
 
 typedef struct {
-    /* Lifecycle */
+    /* Lifecycle. frame_cb is required; init_cb / event_cb / cleanup_cb may
+       be NULL. event_cb is declared for API stability but not yet invoked —
+       in this transitional design, frame_cb drives input via
+       platform_poll_events. event dispatch lands in PR 2.4. */
     void (*init_cb)   (void *user_data);
     void (*frame_cb)  (const platform_frame_t *f, void *user_data);
-    void (*event_cb)  (const platform_event_t *e, void *user_data);
+    void (*event_cb)  (const platform_event_t *e, void *user_data); /* WIP — not yet wired */
     void (*cleanup_cb)(void *user_data);
 
-    /* Window config */
+    /* Window config. transparent/resizable/high_dpi are not yet plumbed
+       through platform_run — platform_init currently hardcodes all three.
+       They'll be honored once a caller actually needs to opt out. */
     int         width;
     int         height;
     const char *title;
@@ -289,5 +294,10 @@ typedef struct {
    drives the desc callbacks, and returns when the window closes. The
    application's main() should return platform_run's result. */
 int platform_run(const platform_app_desc_t *desc);
+
+/* Game requests the run loop to exit. The platform_run loop notices on its
+   next iteration, runs cleanup_cb, and returns — even if the OS window is
+   still open. No-op outside platform_run. */
+void platform_request_quit(void);
 
 #endif /* PLATFORM_H */

--- a/src/platform/platform_macos.m
+++ b/src/platform/platform_macos.m
@@ -757,10 +757,75 @@ uint32_t platform_get_window_display_id(void) {
     return num ? (uint32_t)[num unsignedIntValue] : 0;
 }
 
-/* --- New callback API (skeleton — implementation lands in PR 2.2) --- */
+/* --- New callback API --- */
+
+void platform_request_quit(void) {
+    state.running = false;
+}
 
 int platform_run(const platform_app_desc_t *desc) {
-    (void)desc;
-    fprintf(stderr, "platform_run: not implemented yet (skeleton)\n");
-    return -1;
+    if (!desc) return -1;
+    if (desc->width <= 0 || desc->height <= 0) {
+        fprintf(stderr, "platform_run: invalid window size %dx%d\n", desc->width, desc->height);
+        return -1;
+    }
+    /* frame_cb is required: the run loop doesn't pump events itself in this
+       transitional design — frame_cb's call to platform_poll_events drives
+       AppKit. A null frame_cb would hang the app on the first iteration. */
+    if (!desc->frame_cb) {
+        fprintf(stderr, "platform_run: desc->frame_cb is required\n");
+        return -1;
+    }
+
+    const char *title = desc->title ? desc->title : "libcg";
+
+    /* TODO: desc->transparent, desc->resizable, desc->high_dpi are not yet
+       wired through; platform_init currently hardcodes transparent + resizable
+       + hi-dpi backing. Will plumb when callers actually need to opt out. */
+    if (!platform_init(desc->width, desc->height, title)) {
+        fprintf(stderr, "platform_init failed\n");
+        return -1;
+    }
+
+    if (desc->init_cb) desc->init_cb(desc->user_data);
+
+    /* CFAbsoluteTime is a plain double — no autorelease, no allocation per
+       frame. Avoids the unbounded autoreleased-NSDate growth we'd get
+       running this hot loop without a per-iteration @autoreleasepool. */
+    CFAbsoluteTime t0     = CFAbsoluteTimeGetCurrent();
+    CFAbsoluteTime t_prev = t0;
+    uint64_t       frame_index = 0;
+
+    /* TRANSITIONAL: this loop doesn't pump OS events itself — the game's
+       frame_cb is expected to call platform_poll_events() (legacy polled
+       API, internally pumps NSApp). Adding pump_events() here would
+       double-pump because platform_poll_events resets per-frame transition
+       counts at its start, dropping any events the duplicate pump just
+       delivered. Real fix lands in PR 2.4 (event_cb wiring) which
+       restructures the pump path. The @autoreleasepool guards against any
+       autoreleased Obj-C objects frame_cb / present create accumulating. */
+    while (state.running) {
+        @autoreleasepool {
+            CFAbsoluteTime t_now = CFAbsoluteTimeGetCurrent();
+            platform_frame_t frame = {
+                .fb          = &state.fb.pub,
+                .dt          = t_now - t_prev,
+                .time        = t_now - t0,
+                .frame_index = frame_index++,
+            };
+
+            desc->frame_cb(&frame, desc->user_data);
+            /* frame_cb may flip state.running via platform_request_quit, or
+               windowWillClose may have fired during platform_poll_events.
+               Skip the present in either case so we don't blit to a window
+               that's already on its way out. */
+            if (!state.running) break;
+            platform_present();
+            t_prev = t_now;
+        }
+    }
+
+    if (desc->cleanup_cb) desc->cleanup_cb(desc->user_data);
+    platform_shutdown();
+    return 0;
 }


### PR DESCRIPTION
platform_run() owns the main loop: init -> init_cb -> while(running)
{ frame_cb; present } -> cleanup_cb -> shutdown. Game's main() shrinks
to a desc + platform_run call.

main.c's while body becomes on_frame() with all loop-local state lifted
to file-scope statics (minimal churn — proper game_state_t lands when
event_cb arrives in PR 2.4). Q-key now calls platform_request_quit()
instead of mutating an input struct.

No behavior change: still polls events from inside frame_cb. Live-resize
bug not yet fixed — that's PR 2.3 (move render trigger into drawRect:).