### PR TITLE
drop "PR 2.x" phase numbering from comments

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -344,8 +344,9 @@ static void on_cleanup(void *ud) {
 static void on_frame(const platform_frame_t *f, void *ud) {
     (void)ud;
 
-    /* All loop-local state lives here as statics. PR 2.4 will clean these
-       into a proper game_state_t once event-based input lands. */
+    /* All loop-local state lives here as statics. Will be lifted into a
+       proper game_state_t once event-driven input lands and the frame_cb
+       gets a stable user_data instead of polling fresh every call. */
     static bool print_mouse_coords = false;
     static bool bg_checkerboard    = false;
     static bool paint_mode         = false;

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -281,8 +281,8 @@ typedef struct {
 typedef struct {
     /* Lifecycle. frame_cb is required; init_cb / event_cb / cleanup_cb may
        be NULL. event_cb is declared for API stability but not yet invoked —
-       in this transitional design, frame_cb drives input via
-       platform_poll_events. event dispatch lands in PR 2.4. */
+       input is currently driven by frame_cb calling platform_poll_events.
+       Event dispatch through event_cb lands when the polled API retires. */
     void (*init_cb)   (void *user_data);
     void (*frame_cb)  (const platform_frame_t *f, void *user_data);
     void (*event_cb)  (const platform_event_t *e, void *user_data); /* WIP — not yet wired */

--- a/src/platform/platform_macos.m
+++ b/src/platform/platform_macos.m
@@ -920,13 +920,13 @@ int platform_run(const platform_app_desc_t *desc) {
     _libcg_run_t_prev      = _libcg_run_t0;
     _libcg_run_frame_index = 0;
 
-    /* TRANSITIONAL: this loop doesn't pump OS events itself — the game's
-       frame_cb is expected to call platform_poll_events() (legacy polled
-       API, internally pumps NSApp). Adding pump_events() here would
-       double-pump because platform_poll_events resets per-frame transition
-       counts at its start, dropping any events the duplicate pump just
-       delivered. Real fix lands in PR 2.4 (event_cb wiring) which
-       restructures the pump path.
+    /* This loop doesn't pump OS events itself — frame_cb is expected to
+       call platform_poll_events(), which internally pumps NSApp. Adding
+       a pump here would double-pump (platform_poll_events resets per-frame
+       transition counts at its start, so the duplicate's events would be
+       dropped). The longer-term fix is to retire the polled API and have
+       the platform pump events itself, dispatching to the user via an
+       event_cb that fires from inside this loop's iteration.
 
        The @autoreleasepool guards against autoreleased Obj-C objects
        frame_cb / present_frame might create (e.g. NSDate instances inside


### PR DESCRIPTION
Three comments referenced an internal phase plan ("PR 2.4 lands the
fix") that exists nowhere as canonical text. Anyone reading the code
had to guess what 2.4 meant. Replaced each with a plain-language
description of what's still missing.