### PR TITLE
sokol-style platform consolidation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -316,6 +316,29 @@ static void print_displays_with_framebuffer(void) {
     }
 }
 
+/* ============================================================
+   App state. File-scope statics for now; PR after this lifts them
+   into a proper game_state_t struct stuffed into desc->user_data.
+   ============================================================ */
+
+static bool      print_mouse_coords = false;
+static bool      bg_checkerboard    = false;
+static bool      paint_mode         = false;
+static pattern_t pattern            = PATTERN_SOLID;
+static bool      color_input_mode   = false;
+static char      color_input_buf[16] = {0};
+static int       color_input_len    = 0;
+static int       cur_mx = 0, cur_my = 0;       /* tracked from MOUSE_MOVE */
+
+static const char *mouse_button_name(platform_mouse_button_t b) {
+    switch (b) {
+    case PLATFORM_MOUSE_LEFT:   return "left";
+    case PLATFORM_MOUSE_RIGHT:  return "right";
+    case PLATFORM_MOUSE_MIDDLE: return "middle";
+    default:                    return "?";
+    }
+}
+
 static void on_init(void *ud) {
     (void)ud;
     /* Allocate paint canvas at startup framebuffer size (retina-aware).
@@ -324,10 +347,6 @@ static void on_init(void *ud) {
     paint_canvas_w = fb0->width;
     paint_canvas_h = fb0->height;
 
-    /* Compute pixel count once in size_t — keeps the malloc size and the
-       fill-loop bound consistent. int*int overflow would silently wrap and
-       under-fill or under-allocate; size_t is wide enough for any plausible
-       canvas. */
     size_t pixel_count = (size_t)paint_canvas_w * (size_t)paint_canvas_h;
     paint_canvas = malloc(pixel_count * sizeof(u32));
     if (paint_canvas) {
@@ -341,27 +360,75 @@ static void on_cleanup(void *ud) {
     paint_canvas = NULL;
 }
 
-static void on_frame(const platform_frame_t *f, void *ud) {
+static void on_event(const platform_event_t *e, void *ud) {
     (void)ud;
 
-    /* All loop-local state lives here as statics. Will be lifted into a
-       proper game_state_t once event-driven input lands and the frame_cb
-       gets a stable user_data instead of polling fresh every call. */
-    static bool print_mouse_coords = false;
-    static bool bg_checkerboard    = false;
-    static bool paint_mode         = false;
-    static int  last_mx = -1, last_my = -1;
-    static pattern_t pattern = PATTERN_SOLID;
-    static bool color_input_mode = false;
-    static char color_input_buf[16] = {0};
-    static int  color_input_len = 0;
-    static platform_input_t input = {0};
+    switch (e->kind) {
+    case PLATFORM_EV_KEY_DOWN: {
+        platform_key_t k = e->key.key;
 
-    platform_poll_events(&input);
+        /* Color-input mode handles a few keys specially; pass through to
+           the normal switch for non-handled ones (none today, but keeps
+           the mode-switch boundary readable). */
+        if (color_input_mode) {
+            if (k == PLATFORM_KEY_BACKSPACE && color_input_len > 0) {
+                color_input_buf[--color_input_len] = '\0';
+                printf("\r\x1b[Kcolor input: #%s", color_input_buf);
+                fflush(stdout);
+            } else if (k == PLATFORM_KEY_ENTER && !e->key.repeat) {
+                u32 parsed;
+                if (parse_hex_color(color_input_buf, color_input_len, &parsed)) {
+                    s_custom_color = parsed;
+                    pattern = PATTERN_CUSTOM_COLOR;
+                    printf("\ncolor applied: #%s -> 0x%08X\n", color_input_buf, parsed);
+                } else {
+                    printf("\r\x1b[K#%s is not valid format\n", color_input_buf);
+                }
+                color_input_mode = false;
+                color_input_len  = 0;
+                color_input_buf[0] = '\0';
+            } else if (k == PLATFORM_KEY_ESCAPE && !e->key.repeat) {
+                printf("\ncolor input cancelled\n");
+                color_input_mode = false;
+                color_input_len  = 0;
+                color_input_buf[0] = '\0';
+            }
+            return;
+        }
 
-    /* Process text input — may toggle color_input_mode */
-    for (int i = 0; i < input.text_len; i++) {
-        char c = input.text[i];
+        /* Repeating presses ignored for everything below. */
+        if (e->key.repeat) return;
+
+        switch (k) {
+        case PLATFORM_KEY_Q:      platform_request_quit(); break;
+        case PLATFORM_KEY_M:
+            print_mouse_coords = !print_mouse_coords;
+            printf("mouse coord printing: %s\n", print_mouse_coords ? "ON" : "OFF");
+            break;
+        case PLATFORM_KEY_F:      platform_toggle_fullscreen(); break;
+        case PLATFORM_KEY_ESCAPE:
+            if (platform_is_fullscreen()) platform_toggle_fullscreen();
+            break;
+        case PLATFORM_KEY_1: pattern = PATTERN_SOLID; break;
+        case PLATFORM_KEY_2: pattern = PATTERN_GRADIENT; break;
+        case PLATFORM_KEY_3: pattern = PATTERN_CYCLE; break;
+        case PLATFORM_KEY_4: pattern = PATTERN_NOISE; break;
+        case PLATFORM_KEY_B:
+            bg_checkerboard = !bg_checkerboard;
+            printf("background: %s\n", bg_checkerboard ? "checkerboard" : "transparent");
+            break;
+        case PLATFORM_KEY_T: print_displays_with_framebuffer(); break;
+        case PLATFORM_KEY_L: print_window_display_modes(); break;
+        case PLATFORM_KEY_P:
+            paint_mode = !paint_mode;
+            printf("mode: %s\n", paint_mode ? "paint" : "pattern");
+            break;
+        default: break;
+        }
+    } break;
+
+    case PLATFORM_EV_TEXT_INPUT: {
+        char c = e->text.ch[0];
         if (!color_input_mode && c == '#') {
             color_input_mode = true;
             color_input_len  = 0;
@@ -375,111 +442,76 @@ static void on_frame(const platform_frame_t *f, void *ud) {
             printf("\r\x1b[Kcolor input: #%s", color_input_buf);
             fflush(stdout);
         }
-    }
+    } break;
 
-    if (color_input_mode) {
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_BACKSPACE) && color_input_len > 0) {
-            color_input_buf[--color_input_len] = '\0';
-            printf("\r\x1b[Kcolor input: #%s", color_input_buf);
-            fflush(stdout);
+    case PLATFORM_EV_MOUSE_MOVE:
+        cur_mx = e->move.x;
+        cur_my = e->move.y;
+        if (!color_input_mode && print_mouse_coords) {
+            printf("mouse: (%d, %d)\n", cur_mx, cur_my);
         }
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_ENTER)) {
-            u32 parsed;
-            if (parse_hex_color(color_input_buf, color_input_len, &parsed)) {
-                s_custom_color = parsed;
-                pattern = PATTERN_CUSTOM_COLOR;
-                printf("\ncolor applied: #%s -> 0x%08X\n", color_input_buf, parsed);
-            } else {
-                printf("\r\x1b[K#%s is not valid format\n", color_input_buf);
-            }
-            color_input_mode = false;
-            color_input_len  = 0;
-            color_input_buf[0] = '\0';
-        }
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_ESCAPE)) {
-            printf("\ncolor input cancelled\n");
-            color_input_mode = false;
-            color_input_len  = 0;
-            color_input_buf[0] = '\0';
-        }
-    } else {
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_Q))
-            platform_request_quit();
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_M)) {
-            print_mouse_coords = !print_mouse_coords;
-            printf("mouse coord printing: %s\n", print_mouse_coords ? "ON" : "OFF");
-        }
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_F))
-            platform_toggle_fullscreen();
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_ESCAPE) && platform_is_fullscreen())
-            platform_toggle_fullscreen();
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_1)) pattern = PATTERN_SOLID;
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_2)) pattern = PATTERN_GRADIENT;
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_3)) pattern = PATTERN_CYCLE;
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_4)) pattern = PATTERN_NOISE;
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_B)) {
-            bg_checkerboard = !bg_checkerboard;
-            printf("background: %s\n", bg_checkerboard ? "checkerboard" : "transparent");
-        }
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_T)) print_displays_with_framebuffer();
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_L)) print_window_display_modes();
-        if (platform_is_key_pressed(&input, PLATFORM_KEY_P)) {
-            paint_mode = !paint_mode;
-            printf("mode: %s\n", paint_mode ? "paint" : "pattern");
-        }
-    }
+        break;
 
-    /* Mouse output is suppressed while typing a color */
-    if (!color_input_mode) {
-        if (print_mouse_coords && (input.mouse.x != last_mx || input.mouse.y != last_my)) {
-            printf("mouse: (%d, %d)\n", input.mouse.x, input.mouse.y);
-            last_mx = input.mouse.x;
-            last_my = input.mouse.y;
-        }
-        if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_LEFT))
-            printf("mouse left pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
-        if (platform_is_mouse_released(&input, PLATFORM_MOUSE_LEFT))
-            printf("mouse left released at (%d, %d)\n", input.mouse.x, input.mouse.y);
-        if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_RIGHT))
-            printf("mouse right pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
-        if (platform_is_mouse_released(&input, PLATFORM_MOUSE_RIGHT))
-            printf("mouse right released at (%d, %d)\n", input.mouse.x, input.mouse.y);
-        if (platform_is_mouse_pressed(&input, PLATFORM_MOUSE_MIDDLE))
-            printf("mouse middle pressed at (%d, %d)\n", input.mouse.x, input.mouse.y);
-        if (platform_is_mouse_released(&input, PLATFORM_MOUSE_MIDDLE))
-            printf("mouse middle released at (%d, %d)\n", input.mouse.x, input.mouse.y);
-        if (input.mouse.scroll_dx != 0.0f || input.mouse.scroll_dy != 0.0f)
-            printf("scroll: dx=%.1f dy=%.1f\n", (double)input.mouse.scroll_dx, (double)input.mouse.scroll_dy);
+    case PLATFORM_EV_MOUSE_DOWN:
+        if (!color_input_mode)
+            printf("mouse %s pressed at (%d, %d)\n",
+                   mouse_button_name(e->mouse.btn), e->mouse.x, e->mouse.y);
+        break;
+
+    case PLATFORM_EV_MOUSE_UP:
+        if (!color_input_mode)
+            printf("mouse %s released at (%d, %d)\n",
+                   mouse_button_name(e->mouse.btn), e->mouse.x, e->mouse.y);
+        break;
+
+    case PLATFORM_EV_SCROLL:
+        if (!color_input_mode && (e->scroll.dx != 0.0f || e->scroll.dy != 0.0f))
+            printf("scroll: dx=%.1f dy=%.1f\n",
+                   (double)e->scroll.dx, (double)e->scroll.dy);
+        break;
+
+    default:
+        break;
     }
+}
+
+static void on_frame(void *ud) {
+    (void)ud;
+    platform_framebuffer_t *fb = platform_get_framebuffer();
 
     if (paint_mode) {
-        render_paint_mode(f->fb);
+        render_paint_mode(fb);
+        return;
+    }
+
+    /* Background first — either checker or fully transparent.
+       Required so alpha-blended patterns (CUSTOM_COLOR) have a
+       correct base and don't pick up last frame's pixels. */
+    if (bg_checkerboard) {
+        render_checkerboard(fb);
     } else {
-        /* Background first — either checker or fully transparent.
-           Required so alpha-blended patterns (CUSTOM_COLOR) have a
-           correct base and don't pick up last frame's pixels. */
-        if (bg_checkerboard) {
-            render_checkerboard(f->fb);
-        } else {
-            framebuffer_clear(f->fb, 0x00000000);
-        }
-        switch (pattern) {
-            case PATTERN_SOLID:        render_solid(f->fb); break;
-            case PATTERN_GRADIENT:     render_gradient(f->fb); break;
-            case PATTERN_CYCLE:        render_cycle(f->fb, (double)f->frame_index * 0.05); break;
-            case PATTERN_NOISE:        render_noise(f->fb); break;
-            case PATTERN_CUSTOM_COLOR: render_custom_color(f->fb, s_custom_color); break;
-        }
+        framebuffer_clear(fb, 0x00000000);
+    }
+    switch (pattern) {
+        case PATTERN_SOLID:        render_solid(fb); break;
+        case PATTERN_GRADIENT:     render_gradient(fb); break;
+        case PATTERN_CYCLE:        render_cycle(fb, platform_now() * 3.0); break;
+        case PATTERN_NOISE:        render_noise(fb); break;
+        case PATTERN_CUSTOM_COLOR: render_custom_color(fb, s_custom_color); break;
     }
 }
 
 int main(void) {
     return platform_run(&(platform_app_desc_t){
-        .width      = 1280,
-        .height     = 720,
-        .title      = "libcg",
-        .init_cb    = on_init,
-        .frame_cb   = on_frame,
-        .cleanup_cb = on_cleanup,
+        .width       = 1280,
+        .height      = 720,
+        .title       = "libcg",
+        .transparent = true,
+        .resizable   = true,
+        .high_dpi    = true,
+        .init_cb     = on_init,
+        .frame_cb    = on_frame,
+        .event_cb    = on_event,
+        .cleanup_cb  = on_cleanup,
     });
 }

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -50,13 +50,6 @@ typedef enum {
     PLATFORM_KEY_COUNT
 } platform_key_t;
 
-#define PLATFORM_TEXT_BUFFER 16
-
-typedef struct {
-    int  half_transition_count;
-    bool ended_down;
-} platform_button_t;
-
 typedef enum {
     PLATFORM_MOUSE_LEFT   = 0,
     PLATFORM_MOUSE_RIGHT  = 1,
@@ -64,67 +57,138 @@ typedef enum {
     PLATFORM_MOUSE_COUNT
 } platform_mouse_button_t;
 
-typedef struct {
-    platform_button_t buttons[PLATFORM_MOUSE_COUNT];
-    int   x, y;
-    float scroll_dx, scroll_dy;
-} platform_mouse_t;
+/* ============================================================
+   Events. The platform delivers each input event through event_cb
+   exactly once, in arrival order, before the next frame_cb fires.
+   Callers must only read the union member matching event.kind.
+   For PLATFORM_EV_FOCUS / UNFOCUS / QUIT_REQUESTED / NONE the
+   union contents are unspecified.
+   ============================================================ */
+
+typedef enum {
+    PLATFORM_EV_NONE = 0,
+    PLATFORM_EV_KEY_DOWN,
+    PLATFORM_EV_KEY_UP,
+    PLATFORM_EV_TEXT_INPUT,        /* one printable codepoint per event */
+    PLATFORM_EV_MOUSE_DOWN,
+    PLATFORM_EV_MOUSE_UP,
+    PLATFORM_EV_MOUSE_MOVE,
+    PLATFORM_EV_SCROLL,
+    PLATFORM_EV_RESIZE,            /* framebuffer dimensions changed */
+    PLATFORM_EV_FOCUS,             /* no payload */
+    PLATFORM_EV_UNFOCUS,           /* no payload */
+    PLATFORM_EV_QUIT_REQUESTED,    /* no payload */
+    PLATFORM_EV_COUNT
+} platform_event_kind_t;
 
 typedef struct {
-    platform_button_t keys[PLATFORM_KEY_COUNT];
-    platform_mouse_t  mouse;
-    bool quit_requested;
+    platform_key_t key;
+    bool           repeat;
+} platform_key_event_t;
 
-    /* text input typed this frame (printable characters only) */
-    char  text[PLATFORM_TEXT_BUFFER];
-    int   text_len;
-} platform_input_t;
+typedef struct {
+    char ch[8];                      /* one UTF-8 codepoint (1-4 bytes) + null terminator */
+} platform_text_event_t;
 
-static inline bool platform_is_key_down(const platform_input_t *input, platform_key_t k) {
-    return input->keys[k].ended_down;
-}
-static inline bool platform_is_key_pressed(const platform_input_t *input, platform_key_t k) {
-    return input->keys[k].half_transition_count >= 1 && input->keys[k].ended_down;
-}
-static inline bool platform_is_key_released(const platform_input_t *input, platform_key_t k) {
-    return input->keys[k].half_transition_count >= 1 && !input->keys[k].ended_down;
-}
+typedef struct {
+    platform_mouse_button_t btn;
+    int                     x, y;
+} platform_mouse_event_t;
 
-static inline bool platform_is_mouse_down(const platform_input_t *input, platform_mouse_button_t b) {
-    return input->mouse.buttons[b].ended_down;
-}
-static inline bool platform_is_mouse_pressed(const platform_input_t *input, platform_mouse_button_t b) {
-    return input->mouse.buttons[b].half_transition_count >= 1 && input->mouse.buttons[b].ended_down;
-}
-static inline bool platform_is_mouse_released(const platform_input_t *input, platform_mouse_button_t b) {
-    return input->mouse.buttons[b].half_transition_count >= 1 && !input->mouse.buttons[b].ended_down;
-}
+typedef struct {
+    int x, y;                        /* current cursor position */
+    int dx, dy;                      /* delta since last move */
+} platform_mouse_move_event_t;
 
-/* Lifecycle */
-bool platform_init(int width, int height, const char *title);
-void platform_shutdown(void);
+typedef struct {
+    float dx, dy;
+} platform_scroll_event_t;
 
-/* Per-frame. Polled-API contract:
-   - platform_present() hands the framebuffer to the OS compositor and
-     allocates a fresh one for the next frame. The fb->pixels pointer is
-     not stable across present calls — re-fetch each iteration, do not
-     cache.
-   - The fresh buffer is zero-initialized. Whatever you wrote last frame
-     is gone; render the full frame each iteration (or maintain your own
-     persistent buffer separate from the platform fb). */
-void platform_poll_events(platform_input_t *input);
-void platform_present(void);
+typedef struct {
+    int w, h;                        /* logical points */
+    int fb_w, fb_h;                  /* physical pixels (= w/h × backing scale) */
+} platform_resize_event_t;
 
-/* Accessors. The returned struct pointer is stable, but its `pixels`
-   field changes each platform_present(). Re-read pixels through the
-   struct on every use. */
+typedef struct {
+    platform_event_kind_t kind;
+    uint64_t              frame_index; /* matches platform_frame_count() at delivery */
+
+    union {                            /* anonymous — access as e->key.key */
+        platform_key_event_t        key;
+        platform_text_event_t       text;
+        platform_mouse_event_t      mouse;
+        platform_mouse_move_event_t move;
+        platform_scroll_event_t     scroll;
+        platform_resize_event_t     resize;
+    };
+} platform_event_t;
+
+/* ============================================================
+   App descriptor + entry point. Sokol/SDL3-style: caller fills in
+   a desc struct and platform_run owns the event loop. frame_cb is
+   the only required callback; init_cb / event_cb / cleanup_cb are
+   optional.
+   ============================================================ */
+
+typedef struct {
+    /* Lifecycle */
+    void (*init_cb)   (void *user_data);
+    void (*frame_cb)  (void *user_data);                                  /* required */
+    void (*event_cb)  (const platform_event_t *e, void *user_data);
+    void (*cleanup_cb)(void *user_data);
+
+    /* Window config */
+    int         width;
+    int         height;
+    const char *title;
+    bool        transparent;       /* setOpaque:NO + clearColor */
+    bool        resizable;
+    bool        high_dpi;          /* allocate fb at backing pixel size, not logical */
+
+    /* Opaque pointer passed back to all callbacks */
+    void       *user_data;
+} platform_app_desc_t;
+
+/* The application provides main() and calls platform_run(desc) with its
+   callbacks and window configuration. platform_run owns the event loop,
+   drives the desc callbacks, and returns when the window closes or
+   platform_request_quit() flips the running flag. main() should return
+   platform_run's result. */
+int platform_run(const platform_app_desc_t *desc);
+
+/* Request the run loop to exit. The next iteration runs cleanup_cb and
+   returns from platform_run, even if the OS window is still open.
+   No-op outside platform_run. */
+void platform_request_quit(void);
+
+/* ============================================================
+   Accessors — call from inside any of the desc callbacks.
+   ============================================================ */
+
+/* Writable framebuffer for the current frame. fb->pixels is valid for
+   the duration of one frame_cb call only — do not cache the pointer
+   past the call. fb->width/height reflect the current backing size and
+   may differ from the previous frame after a resize. */
 platform_framebuffer_t *platform_get_framebuffer(void);
+
+/* Monotonic seconds since the start of platform_run. */
+double platform_now(void);
+
+/* Seconds elapsed since the previous frame_cb returned. 0 on the first
+   frame. */
+double platform_dt(void);
+
+/* Number of completed frames (i.e. the index of the current frame_cb
+   call, starting at 0). */
+uint64_t platform_frame_count(void);
 
 /* Window controls */
 void platform_toggle_fullscreen(void);
 bool platform_is_fullscreen(void);
 
-/* Display info */
+/* ============================================================
+   Display info (multi-monitor enumeration / video modes).
+   ============================================================ */
 
 typedef enum {
     PLATFORM_CONNECTION_UNKNOWN = 0,
@@ -189,128 +253,5 @@ int platform_get_display_modes(uint32_t display_id, platform_video_mode_t *out, 
 /* CGDirectDisplayID of the display the window is currently on; match against
    platform_display_info_t.id from platform_get_displays. */
 uint32_t platform_get_window_display_id(void);
-
-/* ============================================================
-   New callback-based API (Sokol/SDL3 style — work in progress)
-
-   Game declares an app desc with callbacks and calls platform_run().
-   Platform owns the run loop, event dispatch, and rendering trigger.
-   Replaces the old polled API in subsequent refactor PRs (#17 fix).
-   ============================================================ */
-
-typedef enum {
-    PLATFORM_EV_NONE = 0,
-    PLATFORM_EV_KEY_DOWN,
-    PLATFORM_EV_KEY_UP,
-    PLATFORM_EV_TEXT_INPUT,        /* one printable codepoint per event */
-    PLATFORM_EV_MOUSE_DOWN,
-    PLATFORM_EV_MOUSE_UP,
-    PLATFORM_EV_MOUSE_MOVE,
-    PLATFORM_EV_SCROLL,
-    PLATFORM_EV_RESIZE,            /* framebuffer dimensions changed */
-    PLATFORM_EV_FOCUS,             /* no payload */
-    PLATFORM_EV_UNFOCUS,           /* no payload */
-    PLATFORM_EV_QUIT_REQUESTED,    /* no payload */
-    PLATFORM_EV_COUNT
-} platform_event_kind_t;
-
-/* Per-arm event types — referenced by name from the union in
-   platform_event_t below. Extracted as named typedefs (rather than
-   anonymous structs) so callers can pass single arms to helper functions
-   and so future per-event callbacks can take them by type.
-
-   Payload contract: callers MUST only read the union member matching
-   event.kind. For PLATFORM_EV_FOCUS / UNFOCUS / QUIT_REQUESTED / NONE,
-   the union contents are unspecified — there is no payload arm to read.
-   Multi-character paste-style input is delivered as multiple events,
-   one PLATFORM_EV_TEXT_INPUT per codepoint. */
-
-typedef struct {
-    platform_key_t key;
-    bool           repeat;
-} platform_key_event_t;
-
-typedef struct {
-    char ch[8];                      /* one UTF-8 codepoint (1-4 bytes) + null terminator */
-} platform_text_event_t;
-
-typedef struct {
-    platform_mouse_button_t btn;
-    int                     x, y;
-} platform_mouse_event_t;
-
-typedef struct {
-    int x, y;                        /* current cursor position */
-    int dx, dy;                      /* delta since last move */
-} platform_mouse_move_event_t;
-
-typedef struct {
-    float dx, dy;
-} platform_scroll_event_t;
-
-typedef struct {
-    int w, h;                        /* logical points */
-    int fb_w, fb_h;                  /* physical pixels (= w/h × backing scale) */
-} platform_resize_event_t;
-
-typedef struct {
-    platform_event_kind_t kind;
-    uint64_t              frame_index; /* same numbering as platform_frame_t.frame_index */
-
-    union {                            /* anonymous — access as e->key.key */
-        platform_key_event_t        key;
-        platform_text_event_t       text;
-        platform_mouse_event_t      mouse;
-        platform_mouse_move_event_t move;
-        platform_scroll_event_t     scroll;
-        platform_resize_event_t     resize;
-    };
-} platform_event_t;
-
-typedef struct {
-    /* Writable backing buffer. fb->pixels is valid for the duration of
-       this frame_cb call only — do not cache the pointer past the call.
-       The platform hands ownership of the buffer to the OS compositor on
-       commit and allocates a fresh one for the next frame. */
-    platform_framebuffer_t *fb;
-    double                  dt;        /* seconds since last frame */
-    double                  time;      /* seconds since app start */
-    uint64_t                frame_index;
-} platform_frame_t;
-
-typedef struct {
-    /* Lifecycle. frame_cb is required; init_cb / event_cb / cleanup_cb may
-       be NULL. event_cb is declared for API stability but not yet invoked —
-       input is currently driven by frame_cb calling platform_poll_events.
-       Event dispatch through event_cb lands when the polled API retires. */
-    void (*init_cb)   (void *user_data);
-    void (*frame_cb)  (const platform_frame_t *f, void *user_data);
-    void (*event_cb)  (const platform_event_t *e, void *user_data); /* WIP — not yet wired */
-    void (*cleanup_cb)(void *user_data);
-
-    /* Window config. transparent/resizable/high_dpi are not yet plumbed
-       through platform_run — platform_init currently hardcodes all three.
-       They'll be honored once a caller actually needs to opt out. */
-    int         width;
-    int         height;
-    const char *title;
-    bool        transparent;       /* setOpaque:NO + clearColor */
-    bool        resizable;
-    bool        high_dpi;
-
-    /* Opaque pointer passed back to all callbacks */
-    void       *user_data;
-} platform_app_desc_t;
-
-/* The application provides main() and calls platform_run(desc) with its
-   callbacks and window configuration. platform_run owns the event loop,
-   drives the desc callbacks, and returns when the window closes. The
-   application's main() should return platform_run's result. */
-int platform_run(const platform_app_desc_t *desc);
-
-/* Game requests the run loop to exit. The platform_run loop notices on its
-   next iteration, runs cleanup_cb, and returns — even if the OS window is
-   still open. No-op outside platform_run. */
-void platform_request_quit(void);
 
 #endif /* PLATFORM_H */

--- a/src/platform/platform_macos.m
+++ b/src/platform/platform_macos.m
@@ -7,7 +7,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Buffer ownership model:
+/* ============================================================
+   Event queue. NSResponder methods on LibcgView and NSWindowDelegate
+   methods on AppDelegate enqueue platform_event_t. drain_event_queue
+   drains the queue and dispatches each via desc->event_cb. Drain runs
+   at the top of present_frame, so ordering is: pump_events fills the
+   queue → present_frame drains it → frame_cb runs → commit. During
+   tracking-mode resize the delegate calls present_frame directly,
+   which still drains its own queued resize events before frame_cb.
+   ============================================================ */
+
+#define EVENT_QUEUE_CAPACITY 256
+
+/* ============================================================
+   Buffer ownership model:
    - state.fb.pixels is the active rendering target. frame_cb writes into it.
    - On commit_to_layer the buffer is handed (no copy) to a CGDataProvider
      whose release callback frees it. The CGImage built from that provider
@@ -16,16 +29,28 @@
    - commit_to_layer then allocates a fresh state.fb.pixels at state.next_w
      × state.next_h for the following frame.
    - Resize delegates only update state.next_w/h. The size flips on the
-     next sync_fb_size — never mid-frame, never inside the pump. This kills
-     the realloc-vs-present race at the architectural level. */
+     next sync_fb_size — never mid-frame, never inside the pump.
+   ============================================================ */
 typedef struct {
     NSApplication *ns_app;
     NSWindow *ns_window;
     NSView *ns_view;
     platform_framebuffer_t fb;     /* pixels owned for one frame at a time */
     int next_w, next_h;            /* pending backing size */
-    platform_input_t pending;
+    int last_mouse_x, last_mouse_y;/* for synthesizing dx/dy on MOUSE_MOVE */
     bool running;
+
+    /* Event ring buffer */
+    platform_event_t events[EVENT_QUEUE_CAPACITY];
+    int events_head;
+    int events_tail;
+
+    /* Active platform_run desc + timing */
+    const platform_app_desc_t *active_desc;
+    CFAbsoluteTime t0;
+    CFAbsoluteTime t_prev;
+    CFAbsoluteTime t_now;          /* start-of-current-frame_cb timestamp */
+    uint64_t frame_count;
 } platform_state_t;
 
 static platform_state_t state;
@@ -89,23 +114,54 @@ static const platform_key_t kc_to_key[256] = {
 };
 // clang-format on
 
-/* --- LibcgView (custom NSView; presentation is via layer.contents) --- */
+/* --- Forward decls --- */
+static void enqueue_event(const platform_event_t *e);
+static void sync_fb_size(void);
+static void present_frame(void);
+static void commit_to_layer(void);
+static NSSize get_backing_size(NSWindow *window);
 
-/* Forward decls for rendering helpers; full bodies live further down. */
-static void sync_fb_size(void);      /* ensure fb.pixels matches next_w/next_h */
-static void present_frame(void);     /* run frame_cb, then hand fb to the layer */
+/* Push an event into the ring buffer. Drops on overflow (logs to stderr).
+   Single-threaded — only called from AppKit handlers and delegate
+   methods on the main thread. */
+static void enqueue_event(const platform_event_t *e) {
+    int next = (state.events_tail + 1) % EVENT_QUEUE_CAPACITY;
+    if (next == state.events_head) {
+        fprintf(stderr, "platform: event queue full, dropping event kind=%d\n", e->kind);
+        return;
+    }
+    state.events[state.events_tail] = *e;
+    state.events[state.events_tail].frame_index = state.frame_count;
+    state.events_tail = next;
+}
+
+/* Drain queued events into desc->event_cb. Called from present_frame
+   before frame_cb. Drops all events if event_cb is NULL. */
+static void drain_event_queue(void) {
+    if (!state.active_desc) {
+        state.events_head = state.events_tail;
+        return;
+    }
+    if (!state.active_desc->event_cb) {
+        state.events_head = state.events_tail;
+        return;
+    }
+    while (state.events_head != state.events_tail) {
+        platform_event_t e = state.events[state.events_head];
+        state.events_head = (state.events_head + 1) % EVENT_QUEUE_CAPACITY;
+        state.active_desc->event_cb(&e, state.active_desc->user_data);
+    }
+}
+
+/* --- LibcgView (custom NSView; NSResponder for input events) --- */
 
 @interface LibcgView : NSView
 @end
 
 @implementation LibcgView
-/* No-op. This is a layer-backed view and frames flow into layer.contents
-   via present_frame() (callback API) / platform_present() (legacy polled
-   API). AppKit composites the current layer.contents on its own for
-   damage / expose / occlusion — drawRect: doesn't need to repaint anything.
-   Calling commit_to_layer here was the source of the startup flash: AppKit
-   could fire drawRect: during view setup before any frame had been
-   rendered, committing an all-zero (transparent) buffer to layer.contents. */
+/* No-op. Layer-backed view with explicit layer.contents — frames flow into
+   the layer via commit_to_layer. AppKit composites the existing contents
+   on damage / expose / occlusion without our involvement. */
 - (void)drawRect:(NSRect)dirtyRect {
     (void)dirtyRect;
 }
@@ -120,52 +176,60 @@ static void present_frame(void);     /* run frame_cb, then hand fb to the layer 
     return YES;
 }
 
-// Record key-down transition. Repeats are filtered — we track physical
-// press/release, not the OS auto-repeat stream.
-- (void)keyDown:(NSEvent *)event {
-    platform_key_t key = kc_to_key[[event keyCode] & 0xFF];
-    if (key == PLATFORM_KEY_UNKNOWN)
-        return;
-    state.pending.keys[key].half_transition_count++;
-    if (![event isARepeat]) {
-        state.pending.keys[key].ended_down = true;
-    }
+- (void)keyDown:(NSEvent *)nsevent {
+    platform_key_t key = kc_to_key[[nsevent keyCode] & 0xFF];
+    if (key == PLATFORM_KEY_UNKNOWN) return;
 
-    /* Capture printable characters into the text input buffer */
-    NSString *chars = [event characters];
+    platform_event_t e = {
+        .kind = PLATFORM_EV_KEY_DOWN,
+        .key  = { .key = key, .repeat = (bool)[nsevent isARepeat] },
+    };
+    enqueue_event(&e);
+
+    /* Capture printable ASCII characters as PLATFORM_EV_TEXT_INPUT events,
+       one per codepoint. Multi-byte UTF-8 input would land here as multiple
+       single-byte events — caller would see fragmented codepoints. The
+       platform_text_event_t.ch array can hold a full 1-4 byte codepoint;
+       extending to proper UTF-8 codepoint slicing is a follow-up. */
+    NSString *chars = [nsevent characters];
     if (chars && [chars length] > 0) {
         const char *cstr = [chars UTF8String];
-        for (const char *p = cstr; *p && state.pending.text_len < PLATFORM_TEXT_BUFFER - 1; p++) {
+        for (const char *p = cstr; *p; p++) {
             unsigned char c = (unsigned char)*p;
             if (c >= 0x20 && c < 0x7F) {
-                state.pending.text[state.pending.text_len++] = (char)c;
+                platform_event_t te = {
+                    .kind = PLATFORM_EV_TEXT_INPUT,
+                };
+                te.text.ch[0] = (char)c;
+                te.text.ch[1] = '\0';
+                enqueue_event(&te);
             }
         }
-        state.pending.text[state.pending.text_len] = '\0';
     }
 }
 
-// Record key-up transition.
-- (void)keyUp:(NSEvent *)event {
-    platform_key_t key = kc_to_key[[event keyCode] & 0xFF];
-    if (key == PLATFORM_KEY_UNKNOWN)
-        return;
-    state.pending.keys[key].half_transition_count++;
-    state.pending.keys[key].ended_down = false;
+- (void)keyUp:(NSEvent *)nsevent {
+    platform_key_t key = kc_to_key[[nsevent keyCode] & 0xFF];
+    if (key == PLATFORM_KEY_UNKNOWN) return;
+
+    platform_event_t e = {
+        .kind = PLATFORM_EV_KEY_UP,
+        .key  = { .key = key, .repeat = false },
+    };
+    enqueue_event(&e);
 }
 
 // Modifier keys (shift, ctrl, alt, cmd, caps lock) don't fire keyDown:/keyUp:.
-// AppKit sends flagsChanged: instead. We use device-specific masks (NX_DEVICE*)
+// AppKit sends flagsChanged: instead. Use device-specific masks (NX_DEVICE*)
 // from IOKit to distinguish left from right modifiers — the high-level
 // NSEventModifierFlag* constants merge both sides into one bit.
 // clang-format off
-- (void)flagsChanged:(NSEvent *)event {
-    unsigned short keyCode = [event keyCode] & 0xFF;
+- (void)flagsChanged:(NSEvent *)nsevent {
+    unsigned short keyCode = [nsevent keyCode] & 0xFF;
     platform_key_t key = kc_to_key[keyCode];
-    if (key == PLATFORM_KEY_UNKNOWN)
-        return;
+    if (key == PLATFORM_KEY_UNKNOWN) return;
 
-    NSUInteger flags = [event modifierFlags];
+    NSUInteger flags = [nsevent modifierFlags];
     bool is_down;
     switch (keyCode) {
         case 0x38: is_down = (flags & NX_DEVICELSHIFTKEYMASK) != 0; break;
@@ -181,65 +245,66 @@ static void present_frame(void);     /* run frame_cb, then hand fb to the layer 
     }
     // clang-format on
 
-    if (is_down != state.pending.keys[key].ended_down) {
-        state.pending.keys[key].half_transition_count++;
-        state.pending.keys[key].ended_down = is_down;
-    }
+    platform_event_t e = {
+        .kind = is_down ? PLATFORM_EV_KEY_DOWN : PLATFORM_EV_KEY_UP,
+        .key  = { .key = key, .repeat = false },
+    };
+    enqueue_event(&e);
 }
 
-- (void)updateMousePosition:(NSEvent *)event {
-    NSPoint local = [self convertPoint:[event locationInWindow] fromView:nil];
-    state.pending.mouse.x = (int)local.x;
-    state.pending.mouse.y = (int)local.y;
+- (NSPoint)mousePosition:(NSEvent *)nsevent {
+    return [self convertPoint:[nsevent locationInWindow] fromView:nil];
 }
 
-- (void)mouseMoved:(NSEvent *)event {
-    [self updateMousePosition:event];
-}
-- (void)mouseDragged:(NSEvent *)event {
-    [self updateMousePosition:event];
-}
-- (void)rightMouseDragged:(NSEvent *)event {
-    [self updateMousePosition:event];
-}
-- (void)otherMouseDragged:(NSEvent *)event {
-    [self updateMousePosition:event];
-}
-
-- (void)mouseDown:(NSEvent *)event {
-    [self updateMousePosition:event];
-    state.pending.mouse.buttons[PLATFORM_MOUSE_LEFT].half_transition_count++;
-    state.pending.mouse.buttons[PLATFORM_MOUSE_LEFT].ended_down = true;
-}
-- (void)mouseUp:(NSEvent *)event {
-    [self updateMousePosition:event];
-    state.pending.mouse.buttons[PLATFORM_MOUSE_LEFT].half_transition_count++;
-    state.pending.mouse.buttons[PLATFORM_MOUSE_LEFT].ended_down = false;
-}
-- (void)rightMouseDown:(NSEvent *)event {
-    [self updateMousePosition:event];
-    state.pending.mouse.buttons[PLATFORM_MOUSE_RIGHT].half_transition_count++;
-    state.pending.mouse.buttons[PLATFORM_MOUSE_RIGHT].ended_down = true;
-}
-- (void)rightMouseUp:(NSEvent *)event {
-    [self updateMousePosition:event];
-    state.pending.mouse.buttons[PLATFORM_MOUSE_RIGHT].half_transition_count++;
-    state.pending.mouse.buttons[PLATFORM_MOUSE_RIGHT].ended_down = false;
-}
-- (void)otherMouseDown:(NSEvent *)event {
-    [self updateMousePosition:event];
-    state.pending.mouse.buttons[PLATFORM_MOUSE_MIDDLE].half_transition_count++;
-    state.pending.mouse.buttons[PLATFORM_MOUSE_MIDDLE].ended_down = true;
-}
-- (void)otherMouseUp:(NSEvent *)event {
-    [self updateMousePosition:event];
-    state.pending.mouse.buttons[PLATFORM_MOUSE_MIDDLE].half_transition_count++;
-    state.pending.mouse.buttons[PLATFORM_MOUSE_MIDDLE].ended_down = false;
+- (void)dispatchMouseMove:(NSEvent *)nsevent {
+    NSPoint p = [self mousePosition:nsevent];
+    int x = (int)p.x, y = (int)p.y;
+    platform_event_t e = {
+        .kind = PLATFORM_EV_MOUSE_MOVE,
+        .move = {
+            .x = x, .y = y,
+            .dx = x - state.last_mouse_x,
+            .dy = y - state.last_mouse_y,
+        },
+    };
+    state.last_mouse_x = x;
+    state.last_mouse_y = y;
+    enqueue_event(&e);
 }
 
-- (void)scrollWheel:(NSEvent *)event {
-    state.pending.mouse.scroll_dx += (float)[event scrollingDeltaX];
-    state.pending.mouse.scroll_dy += (float)[event scrollingDeltaY];
+- (void)mouseMoved:(NSEvent *)nsevent        { [self dispatchMouseMove:nsevent]; }
+- (void)mouseDragged:(NSEvent *)nsevent      { [self dispatchMouseMove:nsevent]; }
+- (void)rightMouseDragged:(NSEvent *)nsevent { [self dispatchMouseMove:nsevent]; }
+- (void)otherMouseDragged:(NSEvent *)nsevent { [self dispatchMouseMove:nsevent]; }
+
+- (void)dispatchMouseButton:(NSEvent *)nsevent kind:(platform_event_kind_t)kind btn:(platform_mouse_button_t)btn {
+    NSPoint p = [self mousePosition:nsevent];
+    int x = (int)p.x, y = (int)p.y;
+    platform_event_t e = {
+        .kind = kind,
+        .mouse = { .btn = btn, .x = x, .y = y },
+    };
+    enqueue_event(&e);
+    state.last_mouse_x = x;
+    state.last_mouse_y = y;
+}
+
+- (void)mouseDown:(NSEvent *)e        { [self dispatchMouseButton:e kind:PLATFORM_EV_MOUSE_DOWN btn:PLATFORM_MOUSE_LEFT]; }
+- (void)mouseUp:(NSEvent *)e          { [self dispatchMouseButton:e kind:PLATFORM_EV_MOUSE_UP   btn:PLATFORM_MOUSE_LEFT]; }
+- (void)rightMouseDown:(NSEvent *)e   { [self dispatchMouseButton:e kind:PLATFORM_EV_MOUSE_DOWN btn:PLATFORM_MOUSE_RIGHT]; }
+- (void)rightMouseUp:(NSEvent *)e     { [self dispatchMouseButton:e kind:PLATFORM_EV_MOUSE_UP   btn:PLATFORM_MOUSE_RIGHT]; }
+- (void)otherMouseDown:(NSEvent *)e   { [self dispatchMouseButton:e kind:PLATFORM_EV_MOUSE_DOWN btn:PLATFORM_MOUSE_MIDDLE]; }
+- (void)otherMouseUp:(NSEvent *)e     { [self dispatchMouseButton:e kind:PLATFORM_EV_MOUSE_UP   btn:PLATFORM_MOUSE_MIDDLE]; }
+
+- (void)scrollWheel:(NSEvent *)nsevent {
+    platform_event_t e = {
+        .kind = PLATFORM_EV_SCROLL,
+        .scroll = {
+            .dx = (float)[nsevent scrollingDeltaX],
+            .dy = (float)[nsevent scrollingDeltaY],
+        },
+    };
+    enqueue_event(&e);
 }
 @end
 
@@ -250,125 +315,59 @@ static void present_frame(void);     /* run frame_cb, then hand fb to the layer 
 
 static NSApplication *create_application(void);
 static NSMenu *create_menu(const char *title);
-static NSWindow *create_window(int w, int h, const char *title, id delegate);
-static NSSize get_backing_size(NSWindow *window);
+static NSWindow *create_window(const platform_app_desc_t *desc, id delegate);
 static void activate_app(NSApplication *app);
 static void pump_events(NSApplication *app);
-static void commit_to_layer(void);
+static bool platform_init(const platform_app_desc_t *desc);
+static void platform_shutdown(void);
 
-/* --- Public API --- */
-
-bool platform_init(int width, int height, const char *title) {
-    state.ns_app = create_application();
-
-    AppDelegate *delegate = [[AppDelegate alloc] init];
-    [state.ns_app setDelegate:delegate];
-
-    [state.ns_app setMainMenu:create_menu(title)];
-
-    state.ns_window = create_window(width, height, title, delegate);
-
-    state.ns_view = [[LibcgView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
-    [state.ns_window setContentView:state.ns_view];
-    [state.ns_window makeFirstResponder:state.ns_view];
-    [state.ns_window setAcceptsMouseMovedEvents:YES];
-
-    /* Layer-backed view with explicit content-placement. Presentation works
-       by assigning CGImages to view.layer.contents — the only path that
-       updates pixels mid-drag during a live resize. The placement controls
-       how the CALayer scales contents when the view bounds change. */
-    [state.ns_view setWantsLayer:YES];
-    state.ns_view.layerContentsPlacement = NSViewLayerContentsPlacementScaleProportionallyToFit;
-
-    // On retina/HiDPI displays the backing store is larger than the logical
-    // window size (e.g. 1280×720 logical → 2560×1440 backing at 2× scale).
-    // Allocate the framebuffer at backing resolution so we render at native
-    // pixel density.
-    NSSize backing = get_backing_size(state.ns_window);
-    state.next_w  = (int)backing.width;
-    state.next_h  = (int)backing.height;
-    state.fb.width  = state.next_w;
-    state.fb.height = state.next_h;
-    state.fb.pixels = calloc((size_t)state.next_w * (size_t)state.next_h, sizeof(uint32_t));
-
-    activate_app(state.ns_app);
-    pump_events(state.ns_app);
-
-    state.running = true;
-    return true;
-}
-
-void platform_shutdown(void) {
-    free(state.fb.pixels);
-    state.fb.pixels = NULL;
-    [state.ns_window close];
-    state.running = false;
-}
-
-void platform_poll_events(platform_input_t *input) {
-    // Reset per-frame transition counts, preserve held state.
-    for (int i = 0; i < PLATFORM_KEY_COUNT; i++)
-        state.pending.keys[i].half_transition_count = 0;
-    for (int i = 0; i < PLATFORM_MOUSE_COUNT; i++)
-        state.pending.mouse.buttons[i].half_transition_count = 0;
-    state.pending.mouse.scroll_dx = 0.0f;
-    state.pending.mouse.scroll_dy = 0.0f;
-    state.pending.text_len = 0;
-    state.pending.text[0] = '\0';
-    // mouse_x, mouse_y persist in state.pending across frames.
-
-    pump_events(state.ns_app);
-
-    /* Apply any resize that fired from a delegate during pump_events
-       BEFORE the caller observes fb. Otherwise the legacy polled API
-       would render one frame at the previous size after every resize
-       (caller reads stale fb dims, renders, presents at stale size). */
-    sync_fb_size();
-
-    *input = state.pending;
-    input->quit_requested = !state.running;
-}
-
-void platform_present(void) {
-    /* Hands fb.pixels to the layer (ownership transfer; the layer owns it
-       until the next commit replaces it) and allocates a fresh fb.pixels
-       for the next frame at the pending size. Polled-API callers must
-       re-fetch via platform_get_framebuffer() each iteration — the pointer
-       is per-frame, not stable across present calls. */
-    commit_to_layer();
-}
-
-platform_framebuffer_t *platform_get_framebuffer(void) {
-    return &state.fb;
-}
-
-/* --- AppDelegate implementation --- */
+/* --- AppDelegate (NSWindowDelegate) --- */
 
 @implementation AppDelegate
 
-// Manual event pump doesn't run the runloop deep enough to trigger AppKit's
-// auto-terminate flow, so hook the window-close notification directly and
-// drop `running` to exit the C main loop.
 - (void)windowWillClose:(NSNotification *)notification {
     (void)notification;
     state.running = false;
+    platform_event_t e = { .kind = PLATFORM_EV_QUIT_REQUESTED };
+    enqueue_event(&e);
 }
 
-/* All resize delegates do the same thing: stash the new backing size in
-   state.next_w/h and trigger a present. The buffer doesn't get touched
-   here — sync_fb_size at the top of present_frame (or commit_to_layer's
-   tail allocation) flips to the new size between frames, never mid-frame.
-   This is why we don't need re-entry-safe reallocate_framebuffer anymore:
-   the dangerous "free buffer being written to" sequence can't form. */
-static void update_pending_size(void) {
+- (void)windowDidBecomeKey:(NSNotification *)notification {
+    (void)notification;
+    platform_event_t e = { .kind = PLATFORM_EV_FOCUS };
+    enqueue_event(&e);
+}
+
+- (void)windowDidResignKey:(NSNotification *)notification {
+    (void)notification;
+    platform_event_t e = { .kind = PLATFORM_EV_UNFOCUS };
+    enqueue_event(&e);
+}
+
+/* All resize delegates: stash the new backing size in state.next_w/h,
+   queue a PLATFORM_EV_RESIZE, then trigger a present so frames keep
+   flowing during AppKit's tracking-mode runloop. */
+static void update_pending_size_and_queue_event(void) {
     NSSize backing = get_backing_size(state.ns_window);
     state.next_w = (int)backing.width;
     state.next_h = (int)backing.height;
+
+    NSRect content = [state.ns_window contentRectForFrameRect:[state.ns_window frame]];
+    platform_event_t e = {
+        .kind = PLATFORM_EV_RESIZE,
+        .resize = {
+            .w    = (int)content.size.width,
+            .h    = (int)content.size.height,
+            .fb_w = state.next_w,
+            .fb_h = state.next_h,
+        },
+    };
+    enqueue_event(&e);
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
     (void)notification;
-    update_pending_size();
+    update_pending_size_and_queue_event();
     present_frame();
 }
 
@@ -378,7 +377,7 @@ static void update_pending_size(void) {
 // the backing pixel size does, and our framebuffer needs to follow.
 - (void)windowDidChangeBackingProperties:(NSNotification *)notification {
     (void)notification;
-    update_pending_size();
+    update_pending_size_and_queue_event();
     present_frame();
 }
 
@@ -387,7 +386,7 @@ static void update_pending_size(void) {
 // next_w/next_h won't change.
 - (void)windowDidChangeScreen:(NSNotification *)notification {
     (void)notification;
-    update_pending_size();
+    update_pending_size_and_queue_event();
     present_frame();
 }
 
@@ -403,12 +402,8 @@ static NSSize get_backing_size(NSWindow *window) {
     return [view convertSizeToBacking:logical];
 }
 
-/* Bring fb.pixels in line with the pending size. Called at the top of
-   present_frame so the size only flips between frames, never mid-frame.
-   Same-size is a no-op. The old buffer (if any) is freed; the new one
-   is calloc'd fresh — frame_cb is expected to fully overwrite it, but
-   zero-init is cheap insurance against a frame_cb that reads before it
-   writes. */
+/* Bring fb.pixels in line with the pending size. Same-size = no-op.
+   Old buffer (if any) is freed; new one is calloc'd fresh. */
 static void sync_fb_size(void) {
     if (state.fb.pixels && state.fb.width == state.next_w && state.fb.height == state.next_h) {
         return;
@@ -426,14 +421,11 @@ static NSApplication *create_application(void) {
 }
 
 // Build a minimal menu bar: one app menu with a Quit item bound to Cmd-Q.
-// Caller is responsible for installing it via setMainMenu:.
 static NSMenu *create_menu(const char *title) {
-    // top bar + first slot (AppKit auto-labels this with the app name)
     NSMenu *menubar = [[NSMenu alloc] init];
     NSMenuItem *appMenuItem = [[NSMenuItem alloc] init];
     [menubar addItem:appMenuItem];
 
-    // dropdown that hangs off the app slot, with just "Quit <title>" in it
     NSMenu *appMenu = [[NSMenu alloc] init];
     NSString *quitTitle = [NSString stringWithFormat:@"Quit %s", title];
     NSMenuItem *quitItem = [[NSMenuItem alloc] initWithTitle:quitTitle
@@ -445,24 +437,26 @@ static NSMenu *create_menu(const char *title) {
     return menubar;
 }
 
-static NSWindow *create_window(int width, int height, const char *title, id delegate) {
-    // clang-format off
+static NSWindow *create_window(const platform_app_desc_t *desc, id delegate) {
     NSUInteger style = NSWindowStyleMaskTitled
                      | NSWindowStyleMaskClosable
-                     | NSWindowStyleMaskMiniaturizable
-                     | NSWindowStyleMaskResizable;
-    // clang-format on
+                     | NSWindowStyleMaskMiniaturizable;
+    if (desc->resizable) style |= NSWindowStyleMaskResizable;
 
-    NSRect frame = NSMakeRect(0, 0, width, height);
+    NSRect frame = NSMakeRect(0, 0, desc->width, desc->height);
     NSWindow *window = [[NSWindow alloc] initWithContentRect:frame
                                                    styleMask:style
                                                      backing:NSBackingStoreBuffered
                                                        defer:NO];
-    [window setTitle:[NSString stringWithUTF8String:title]];
+    [window setTitle:[NSString stringWithUTF8String:desc->title ? desc->title : "libcg"]];
     [window center];
     [window setDelegate:delegate];
-    [window setOpaque:NO];
-    [window setBackgroundColor:[NSColor clearColor]];
+
+    if (desc->transparent) {
+        [window setOpaque:NO];
+        [window setBackgroundColor:[NSColor clearColor]];
+    }
+
     [window makeKeyAndOrderFront:nil];
     return window;
 }
@@ -480,8 +474,10 @@ static void activate_app(NSApplication *app) {
     }
 }
 
-// Drain any pending events. distantPast = non-blocking poll; never enters the
-// runloop, so runloop sources/timers/observers won't fire here.
+// Drain any pending AppKit events. distantPast = non-blocking poll. The
+// NSResponder methods on LibcgView and NSWindowDelegate methods on
+// AppDelegate (called via [NSApp sendEvent:] / notifications) push
+// platform_event_t entries into our event queue.
 static void pump_events(NSApplication *app) {
     @autoreleasepool {
         NSEvent *event;
@@ -492,6 +488,74 @@ static void pump_events(NSApplication *app) {
             [app sendEvent:event];
         }
     }
+}
+
+static bool platform_init(const platform_app_desc_t *desc) {
+    state.ns_app = create_application();
+
+    AppDelegate *delegate = [[AppDelegate alloc] init];
+    [state.ns_app setDelegate:delegate];
+
+    const char *title = desc->title ? desc->title : "libcg";
+    [state.ns_app setMainMenu:create_menu(title)];
+
+    state.ns_window = create_window(desc, delegate);
+
+    state.ns_view = [[LibcgView alloc] initWithFrame:NSMakeRect(0, 0, desc->width, desc->height)];
+    [state.ns_window setContentView:state.ns_view];
+    [state.ns_window makeFirstResponder:state.ns_view];
+    [state.ns_window setAcceptsMouseMovedEvents:YES];
+
+    [state.ns_view setWantsLayer:YES];
+    state.ns_view.layerContentsPlacement = NSViewLayerContentsPlacementScaleProportionallyToFit;
+
+    /* Allocate framebuffer at backing pixels (HiDPI-aware) or logical points
+       (1× rendering, CALayer scales). */
+    NSSize backing = desc->high_dpi
+        ? get_backing_size(state.ns_window)
+        : NSMakeSize(desc->width, desc->height);
+    state.next_w = (int)backing.width;
+    state.next_h = (int)backing.height;
+    state.fb.width  = state.next_w;
+    state.fb.height = state.next_h;
+    state.fb.pixels = calloc((size_t)state.next_w * (size_t)state.next_h, sizeof(uint32_t));
+
+    activate_app(state.ns_app);
+    pump_events(state.ns_app);
+
+    state.running = true;
+    return true;
+}
+
+static void platform_shutdown(void) {
+    free(state.fb.pixels);
+    state.fb.pixels = NULL;
+    [state.ns_window close];
+    state.running = false;
+}
+
+/* --- Public API --- */
+
+void platform_request_quit(void) {
+    state.running = false;
+}
+
+platform_framebuffer_t *platform_get_framebuffer(void) {
+    return &state.fb;
+}
+
+double platform_now(void) {
+    if (state.t0 == 0.0) return 0.0;
+    return state.t_now - state.t0;
+}
+
+double platform_dt(void) {
+    if (state.t_prev == 0.0) return 0.0;
+    return state.t_now - state.t_prev;
+}
+
+uint64_t platform_frame_count(void) {
+    return state.frame_count;
 }
 
 void platform_toggle_fullscreen(void) {
@@ -766,23 +830,10 @@ uint32_t platform_get_window_display_id(void) {
     return num ? (uint32_t)[num unsignedIntValue] : 0;
 }
 
-/* --- New callback API --- */
-
-/* Static state for the active platform_run invocation.
-   CFAbsoluteTime (plain double) instead of NSDate avoids autorelease
-   accumulation in the hot present_frame loop. */
-static const platform_app_desc_t *_libcg_active_desc     = NULL;
-static CFAbsoluteTime             _libcg_run_t0          = 0.0;
-static CFAbsoluteTime             _libcg_run_t_prev      = 0.0;
-static uint64_t                   _libcg_run_frame_index = 0;
-
-void platform_request_quit(void) {
-    state.running = false;
-}
+/* --- Run loop / present --- */
 
 /* CGDataProvider release callback — frees the pixel buffer that was
-   handed to the layer when the CGImage built around it finally drops
-   (typically when the next commit replaces layer.contents). */
+   handed to the layer when the CGImage built around it finally drops. */
 static void release_fb_buffer(void *info, const void *data, size_t size) {
     (void)info;
     (void)size;
@@ -791,20 +842,7 @@ static void release_fb_buffer(void *info, const void *data, size_t size) {
 
 /* Hand the active fb buffer to the layer (ownership transfer — no copy)
    and immediately allocate a fresh fb buffer at the pending size for the
-   next frame. Bypasses AppKit's drawRect coalescing — Core Animation's
-   main-thread transactions commit during live-resize tracking-mode
-   runloops, so pixels reach screen mid-drag.
-
-   Why ownership transfer (not copy-on-commit):
-   CGBitmapContextCreateImage's documented copy-on-write only triggers on
-   CGContext-API drawing. We mutate pixels via raw pointer writes which CG
-   can't observe, so any CGImage made from a shared bitmap context is
-   effectively aliasing our buffer. The earlier snapshot+provider workaround
-   memcpy'd ~8 MB/frame at retina-720p × 60 Hz. Handing the buffer itself
-   to the data provider is faster and structurally race-free: the buffer
-   lives until the layer drops the image, which only happens when the next
-   commit hands a new buffer. State.fb.pixels is then a fresh allocation
-   that no one else has a pointer to. */
+   next frame. */
 static void commit_to_layer(void) {
     if (!state.fb.pixels || !state.ns_view) return;
 
@@ -828,11 +866,10 @@ static void commit_to_layer(void) {
         false,                             /* no interpolation */
         kCGRenderingIntentDefault);
 
-    /* Wrap the contents assignment in an explicit CATransaction with
-       implicit-actions disabled. Without this the assignment lands in the
-       implicit per-runloop transaction, which only commits when the
-       runloop iterates — but platform_run's tight while loop never enters
-       the runloop. */
+    /* Explicit CATransaction with implicit-actions disabled — assignment
+       commits to the compositor synchronously. The platform_run loop never
+       enters the runloop, so the implicit per-runloop transaction would
+       never fire on its own. */
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     state.ns_view.layer.contents = (__bridge id)img;
@@ -842,50 +879,28 @@ static void commit_to_layer(void) {
     CGDataProviderRelease(provider);
     CGColorSpaceRelease(cs);
 
-    /* Buffer ownership has transferred to the layer's data provider.
+    /* Buffer ownership transferred to the layer's data provider.
        Allocate a fresh one for the next frame at the pending size. */
     state.fb.width  = state.next_w;
     state.fb.height = state.next_h;
     state.fb.pixels = calloc((size_t)state.next_w * (size_t)state.next_h, sizeof(uint32_t));
 }
 
-/* Sync size, run frame_cb (which fills fb), then commit. Bypasses
-   AppKit's drawRect coalescing — Core Animation's main-thread transactions
-   commit during live-resize tracking-mode runloops, which is exactly when
-   we recurse into ourselves: AppKit calls our windowDidResize: delegate
-   from inside frame_cb's platform_poll_events (pump_events → sendEvent →
-   tracking-mode runloop → delegate → present_frame). The recursion is
-   intentional — without it nothing reaches the layer mid-drag and the
-   window stays empty for the duration of the resize. Each recursive
-   call is a real frame at a different size; frame_index/dt advance
-   accordingly, which is the correct accounting. The buffer-ownership
-   model means recursion can no longer free a buffer being written to. */
+/* sync size, drain queued events into event_cb, run frame_cb, commit.
+   Recurses cleanly via AppKit's tracking-mode runloop calling our
+   resize delegates → present_frame, which still drains queued events
+   (the resize was just queued) and presents at the new size. */
 static void present_frame(void) {
-    /* No active platform_run — either the caller is on the legacy polled
-       API path (no frame_cb to invoke) or platform_run already cleared
-       _libcg_active_desc in its cleanup tail and AppKit fired a late
-       delegate notification during [window close]. Nothing to drive, bail. */
-    if (!_libcg_active_desc) return;
+    if (!state.active_desc) return;
 
-    /* Apply any pending resize before frame_cb sees fb. */
     sync_fb_size();
+    drain_event_queue();
 
-    if (_libcg_active_desc->frame_cb) {
-        CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
-        platform_frame_t frame = {
-            .fb          = &state.fb,
-            .dt          = now - _libcg_run_t_prev,
-            .time        = now - _libcg_run_t0,
-            .frame_index = _libcg_run_frame_index++,
-        };
-        _libcg_active_desc->frame_cb(&frame, _libcg_active_desc->user_data);
-        _libcg_run_t_prev = now;
-    }
+    state.t_now = CFAbsoluteTimeGetCurrent();
+    state.active_desc->frame_cb(state.active_desc->user_data);
+    state.t_prev = state.t_now;
+    state.frame_count++;
 
-    /* frame_cb may flip state.running (platform_request_quit, or
-       windowWillClose during platform_poll_events). Skip the commit so we
-       don't push pixels to a window that's on its way out. The run-loop's
-       while-condition will exit on the next iteration. */
     if (state.running) commit_to_layer();
 }
 
@@ -895,54 +910,41 @@ int platform_run(const platform_app_desc_t *desc) {
         fprintf(stderr, "platform_run: invalid window size %dx%d\n", desc->width, desc->height);
         return -1;
     }
-    /* frame_cb is required: the run loop doesn't pump events itself in this
-       transitional design — frame_cb's call to platform_poll_events drives
-       AppKit. A null frame_cb would hang the app on the first iteration. */
     if (!desc->frame_cb) {
         fprintf(stderr, "platform_run: desc->frame_cb is required\n");
         return -1;
     }
 
-    const char *title = desc->title ? desc->title : "libcg";
-
-    /* TODO: desc->transparent, desc->resizable, desc->high_dpi are not yet
-       wired through; platform_init currently hardcodes transparent + resizable
-       + hi-dpi backing. Will plumb when callers actually need to opt out. */
-    if (!platform_init(desc->width, desc->height, title)) {
+    if (!platform_init(desc)) {
         fprintf(stderr, "platform_init failed\n");
         return -1;
     }
 
     if (desc->init_cb) desc->init_cb(desc->user_data);
 
-    _libcg_active_desc     = desc;
-    _libcg_run_t0          = CFAbsoluteTimeGetCurrent();
-    _libcg_run_t_prev      = _libcg_run_t0;
-    _libcg_run_frame_index = 0;
+    state.active_desc = desc;
+    state.t0          = CFAbsoluteTimeGetCurrent();
+    state.t_prev      = state.t0;
+    state.t_now       = state.t0;
+    state.frame_count = 0;
 
-    /* This loop doesn't pump OS events itself — frame_cb is expected to
-       call platform_poll_events(), which internally pumps NSApp. Adding
-       a pump here would double-pump (platform_poll_events resets per-frame
-       transition counts at its start, so the duplicate's events would be
-       dropped). The longer-term fix is to retire the polled API and have
-       the platform pump events itself, dispatching to the user via an
-       event_cb that fires from inside this loop's iteration.
-
-       The @autoreleasepool guards against autoreleased Obj-C objects
-       frame_cb / present_frame might create (e.g. NSDate instances inside
-       AppKit during display) accumulating across frames. */
+    /* Per-iteration: pump AppKit events (handlers enqueue platform_event_t),
+       then present_frame drains the queue, calls frame_cb, commits. */
     while (state.running) {
         @autoreleasepool {
+            pump_events(state.ns_app);
+            if (!state.running) break;
             present_frame();
         }
     }
 
     if (desc->cleanup_cb) desc->cleanup_cb(desc->user_data);
 
-    _libcg_active_desc     = NULL;
-    _libcg_run_t0          = 0.0;
-    _libcg_run_t_prev      = 0.0;
-    _libcg_run_frame_index = 0;
+    state.active_desc = NULL;
+    state.t0          = 0.0;
+    state.t_prev      = 0.0;
+    state.t_now       = 0.0;
+    state.frame_count = 0;
 
     platform_shutdown();
     return 0;


### PR DESCRIPTION
Retires the polled API surface and consolidates around the callback model
that PR #19/#20 set up. Direct port of Sokol/SDL3's per-frame contract:
caller fills a desc, platform_run owns the loop, events flow through
event_cb, frames flow through frame_cb.

Public API after this PR:
  platform_run(desc)                 — only entry point
  platform_request_quit()
  platform_get_framebuffer()         — current frame's writable target
  platform_now() / platform_dt() / platform_frame_count()  — timing accessors
  platform_toggle_fullscreen() / platform_is_fullscreen()
  display-info APIs (unchanged)

What went away:
  platform_init / platform_poll_events / platform_present  — now static internals
  platform_input_t + the platform_is_*_pressed/down/released helpers
  platform_frame_t (was: passed dt/time/frame_index to frame_cb)

Event delivery: NSResponder methods on LibcgView and NSWindowDelegate
methods on AppDelegate enqueue platform_event_t into a 256-slot ring
buffer. drain_event_queue runs at the top of present_frame, dispatching
each event to desc->event_cb in arrival order before frame_cb. The
recursive tracking-mode resize path still works — delegate enqueues a
PLATFORM_EV_RESIZE and calls present_frame, which drains its own event.

Window flags now actually do something:
  desc->transparent → setOpaque:NO + clearColor (was hardcoded on)
  desc->resizable   → NSWindowStyleMaskResizable in styleMask
  desc->high_dpi    → fb at backing pixels vs logical points

Time accessors instead of pushed fields: matches Sokol exactly. Game
pulls platform_now() / platform_dt() / platform_frame_count() when
needed; nothing pushed onto frame_cb.

main.c restructured: input handling moved out of on_frame into a new
on_event. on_frame is now pure rendering, reads only persistent state
flags (paint_mode, pattern, bg_checkerboard, etc.). Pattern cycling
uses platform_now() * 3.0 instead of frame_index * 0.05.