### PR TITLE
paint tools: pencil / brush / eraser, sized brush, drag strokes

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,12 @@ typedef enum {
     MODE_PAINT,
 } app_mode_t;
 
+typedef enum {
+    TOOL_PENCIL = 0,    /* 1px dot at cursor, current color */
+    TOOL_BRUSH,         /* brush_size × brush_size square, current color */
+    TOOL_ERASER,        /* brush_size × brush_size square, white */
+} paint_tool_t;
+
 typedef struct {
     /* main mode */
     app_mode_t mode;
@@ -49,6 +55,13 @@ typedef struct {
     /* paint mode — fixed-size canvas that survives window resizes */
     u32 *paint_canvas;
     int  paint_canvas_w, paint_canvas_h;
+
+    /* paint tool state */
+    paint_tool_t paint_tool;          /* current tool, default TOOL_PENCIL */
+    int          brush_size;          /* size for brush/eraser, 1..32, default 5 */
+    bool         painting;            /* mouse held during a stroke */
+    int          last_paint_cx;       /* prev stroke point in canvas coords */
+    int          last_paint_cy;
 } app_state_t;
 
 /* ============================================================
@@ -486,8 +499,109 @@ static void pattern_on_frame(app_state_t *app, platform_framebuffer_t *fb) {
 }
 
 /* ============================================================
-   Paint mode.
+   Paint mode — pencil / brush / eraser, brush sizing, clear canvas.
+   Mouse coords from events are in logical points; canvas is in
+   framebuffer pixels. Conversion: multiply by platform_get_dpi_scale()
+   to get fb-pixel coords, then subtract the letterbox offset that
+   render_paint_mode applies. Invariant: render_paint_mode and
+   mouse_to_canvas use the same offset formula so cursor lines up
+   exactly with painted pixels.
    ============================================================ */
+
+static const char *tool_name(paint_tool_t t) {
+    switch (t) {
+    case TOOL_PENCIL: return "pencil";
+    case TOOL_BRUSH:  return "brush";
+    case TOOL_ERASER: return "eraser";
+    default:          return "?";
+    }
+}
+
+/* Convert logical-point mouse coords to canvas-pixel coords.
+   Returns false if the cursor is outside the canvas (in the gray
+   letterbox bars). */
+static bool mouse_to_canvas(app_state_t *app, int mouse_x, int mouse_y,
+                            int *out_cx, int *out_cy) {
+    platform_framebuffer_t *fb = platform_get_framebuffer();
+    double scale = platform_get_dpi_scale();
+    int fb_x = (int)(mouse_x * scale);
+    int fb_y = (int)(mouse_y * scale);
+
+    int off_x = (fb->width  - app->paint_canvas_w) / 2;
+    int off_y = (fb->height - app->paint_canvas_h) / 2;
+    int cx = fb_x - off_x;
+    int cy = fb_y - off_y;
+
+    if (cx < 0 || cx >= app->paint_canvas_w) return false;
+    if (cy < 0 || cy >= app->paint_canvas_h) return false;
+    *out_cx = cx;
+    *out_cy = cy;
+    return true;
+}
+
+/* Apply current tool centered at canvas-pixel (cx, cy). Out-of-bounds
+   pixels in the brush footprint are clipped, not wrapped. */
+static void apply_tool_at(app_state_t *app, int cx, int cy) {
+    u32 color;
+    int radius;
+    switch (app->paint_tool) {
+    case TOOL_PENCIL: color = app->custom_color; radius = 0;                       break;
+    case TOOL_BRUSH:  color = app->custom_color; radius = app->brush_size / 2;     break;
+    case TOOL_ERASER: color = 0xFFFFFFFFu;       radius = app->brush_size / 2;     break;
+    default: return;
+    }
+
+    int x0 = cx - radius, x1 = cx + radius;
+    int y0 = cy - radius, y1 = cy + radius;
+    if (x0 < 0) x0 = 0;
+    if (y0 < 0) y0 = 0;
+    if (x1 >= app->paint_canvas_w) x1 = app->paint_canvas_w - 1;
+    if (y1 >= app->paint_canvas_h) y1 = app->paint_canvas_h - 1;
+
+    for (int y = y0; y <= y1; y++) {
+        u32 *row = &app->paint_canvas[y * app->paint_canvas_w];
+        for (int x = x0; x <= x1; x++) row[x] = color;
+    }
+}
+
+/* Bresenham line — fills pixel gaps when the mouse moves faster than
+   one event per pixel. Without this, fast strokes leave a string of
+   dots instead of a continuous line. */
+static void apply_tool_stroke(app_state_t *app, int x0, int y0, int x1, int y1) {
+    int dx =  abs(x1 - x0);
+    int dy = -abs(y1 - y0);
+    int sx = x0 < x1 ? 1 : -1;
+    int sy = y0 < y1 ? 1 : -1;
+    int err = dx + dy;
+    for (;;) {
+        apply_tool_at(app, x0, y0);
+        if (x0 == x1 && y0 == y1) break;
+        int e2 = 2 * err;
+        if (e2 >= dy) { err += dy; x0 += sx; }
+        if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+}
+
+static void paint_canvas_clear(app_state_t *app) {
+    if (!app->paint_canvas) return;
+    size_t n = (size_t)app->paint_canvas_w * (size_t)app->paint_canvas_h;
+    for (size_t i = 0; i < n; i++) app->paint_canvas[i] = 0xFFFFFFFFu;
+    printf("canvas cleared\n");
+}
+
+static void paint_set_tool(app_state_t *app, paint_tool_t t) {
+    app->paint_tool = t;
+    if (t == TOOL_PENCIL) printf("tool: pencil\n");
+    else                  printf("tool: %s (size %d)\n", tool_name(t), app->brush_size);
+}
+
+static void paint_set_brush_size(app_state_t *app, int size) {
+    if (size < 1)  size = 1;
+    if (size > 32) size = 32;
+    app->brush_size = size;
+    if (app->paint_tool == TOOL_BRUSH || app->paint_tool == TOOL_ERASER)
+        printf("brush size: %d\n", app->brush_size);
+}
 
 static void paint_on_event(app_state_t *app, const platform_event_t *e) {
     switch (e->kind) {
@@ -504,17 +618,56 @@ static void paint_on_event(app_state_t *app, const platform_event_t *e) {
             app->mode = MODE_PATTERN;
             printf("mode: pattern\n");
             break;
+
+        /* Tool selection — positional, room to grow as more tools land. */
+        case PLATFORM_KEY_1: paint_set_tool(app, TOOL_PENCIL); break;
+        case PLATFORM_KEY_2: paint_set_tool(app, TOOL_BRUSH);  break;
+        case PLATFORM_KEY_3: paint_set_tool(app, TOOL_ERASER); break;
+
+        /* Brush size: ±1 step. */
+        case PLATFORM_KEY_LEFT_BRACKET:  paint_set_brush_size(app, app->brush_size - 1); break;
+        case PLATFORM_KEY_RIGHT_BRACKET: paint_set_brush_size(app, app->brush_size + 1); break;
+
+        case PLATFORM_KEY_C: paint_canvas_clear(app); break;
+
         default: break;
         }
         break;
-    case PLATFORM_EV_MOUSE_DOWN:
-        printf("mouse %s pressed at (%d, %d)\n",
-               mouse_button_name(e->mouse.btn), e->mouse.x, e->mouse.y);
-        break;
+
+    case PLATFORM_EV_MOUSE_DOWN: {
+        int cx, cy;
+        if (!mouse_to_canvas(app, e->mouse.x, e->mouse.y, &cx, &cy)) break;
+        app->painting      = true;
+        app->last_paint_cx = cx;
+        app->last_paint_cy = cy;
+        apply_tool_at(app, cx, cy);
+    } break;
+
     case PLATFORM_EV_MOUSE_UP:
-        printf("mouse %s released at (%d, %d)\n",
-               mouse_button_name(e->mouse.btn), e->mouse.x, e->mouse.y);
+        app->painting = false;
         break;
+
+    case PLATFORM_EV_MOUSE_MOVE: {
+        if (!app->painting) break;
+        int cx, cy;
+        if (!mouse_to_canvas(app, e->move.x, e->move.y, &cx, &cy)) {
+            /* Cursor left the canvas mid-stroke — drop the segment but
+               don't end the stroke (re-entering the canvas continues
+               from the new position). Reset last_paint to the new spot
+               on re-entry to avoid drawing a long line across the gap. */
+            app->last_paint_cx = -1;
+            app->last_paint_cy = -1;
+            break;
+        }
+        if (app->last_paint_cx < 0) {
+            apply_tool_at(app, cx, cy);
+        } else {
+            apply_tool_stroke(app, app->last_paint_cx, app->last_paint_cy, cx, cy);
+        }
+        app->last_paint_cx = cx;
+        app->last_paint_cy = cy;
+    } break;
+
     default:
         break;
     }
@@ -568,13 +721,14 @@ static void on_cleanup(void *ud) {
 static void on_event(const platform_event_t *e, void *ud) {
     app_state_t *app = ud;
 
-    /* Mouse position tracking happens regardless of mode/overlay. */
+    /* Mouse position tracking — update the cached position regardless of
+       mode/overlay, then fall through so mode handlers can react to the
+       move (e.g. paint mode extends a stroke). */
     if (e->kind == PLATFORM_EV_MOUSE_MOVE) {
         app->mouse_x = e->move.x;
         app->mouse_y = e->move.y;
         if (!app->color_input_active && app->print_mouse_coords)
             printf("mouse: (%d, %d)\n", app->mouse_x, app->mouse_y);
-        return;
     }
 
     if (handle_global_hotkey(e)) return;
@@ -615,6 +769,11 @@ int main(void) {
         .bg_checkerboard    = false,
         .print_mouse_coords = false,
         .color_input_active = false,
+        .paint_tool         = TOOL_PENCIL,
+        .brush_size         = 5,
+        .painting           = false,
+        .last_paint_cx      = -1,
+        .last_paint_cy      = -1,
         /* paint_canvas allocated in on_init from current backing size */
     };
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -182,6 +182,12 @@ double platform_dt(void);
    call, starting at 0). */
 uint64_t platform_frame_count(void);
 
+/* Multiplier from logical-point mouse-event coords to framebuffer-pixel
+   coords. 1.0 when desc->high_dpi is false (fb is at logical points
+   already). On retina with desc->high_dpi true, returns the window's
+   backingScaleFactor (typically 2.0). */
+double platform_get_dpi_scale(void);
+
 /* Window controls */
 void platform_toggle_fullscreen(void);
 bool platform_is_fullscreen(void);

--- a/src/platform/platform_macos.m
+++ b/src/platform/platform_macos.m
@@ -474,19 +474,27 @@ static void activate_app(NSApplication *app) {
     }
 }
 
-// Drain any pending AppKit events. distantPast = non-blocking poll. The
-// NSResponder methods on LibcgView and NSWindowDelegate methods on
-// AppDelegate (called via [NSApp sendEvent:] / notifications) push
-// platform_event_t entries into our event queue.
+// Drain any pending AppKit events. distantPast = non-blocking poll.
+// Polls both NSDefaultRunLoopMode (regular events) and
+// NSEventTrackingRunLoopMode (mouse-drag events: between mouseDown and
+// mouseUp, AppKit queues mouseDragged: events in tracking mode just
+// like it does for live-resize). Without the second pass, drag events
+// pile up invisibly until mouseUp returns control to default mode and
+// the app sees a click without the strokes between.
+static void pump_events_in_mode(NSApplication *app, NSString *mode) {
+    NSEvent *event;
+    while ((event = [app nextEventMatchingMask:NSEventMaskAny
+                                     untilDate:[NSDate distantPast]
+                                        inMode:mode
+                                       dequeue:YES])) {
+        [app sendEvent:event];
+    }
+}
+
 static void pump_events(NSApplication *app) {
     @autoreleasepool {
-        NSEvent *event;
-        while ((event = [app nextEventMatchingMask:NSEventMaskAny
-                                         untilDate:[NSDate distantPast]
-                                            inMode:NSDefaultRunLoopMode
-                                           dequeue:YES])) {
-            [app sendEvent:event];
-        }
+        pump_events_in_mode(app, NSDefaultRunLoopMode);
+        pump_events_in_mode(app, NSEventTrackingRunLoopMode);
     }
 }
 
@@ -556,6 +564,11 @@ double platform_dt(void) {
 
 uint64_t platform_frame_count(void) {
     return state.frame_count;
+}
+
+double platform_get_dpi_scale(void) {
+    if (!state.active_desc || !state.active_desc->high_dpi) return 1.0;
+    return state.ns_window ? (double)[state.ns_window backingScaleFactor] : 1.0;
 }
 
 void platform_toggle_fullscreen(void) {


### PR DESCRIPTION
Paint mode is no longer a viewer for a static canvas — left-mouse drag
actually paints onto it. Pencil tool draws single canvas pixels;
brush draws an N×N square; eraser fills N×N with white.

Bindings (paint mode only — keys reused from pattern mode without
collision because dispatch is mode-scoped):
  1 / 2 / 3      pencil / brush / eraser
  [ / ]          brush size −/+ (clamped to 1..32)
  C              clear canvas to white
  left-click+drag  paint with current tool

Stroke continuity: Bresenham line between previous and current cursor
positions. Without it, fast strokes leave a string of dots — at brush
size 1 it looks completely broken.

Two adjacent fixes the tools turned up:

- main.c on_event was intercepting MOUSE_MOVE to update the cached
  mouse_x/y and then return, swallowing every MOVE before mode
  handlers saw it. Pattern mode didn't notice (only handled buttons);
  paint mode needs MOVE for stroke continuation. Now the dispatcher
  falls through after updating the cache.

- platform pump now drains both NSDefaultRunLoopMode and
  NSEventTrackingRunLoopMode. Some mouse-tracking events queue in
  tracking mode like live-resize does; the second pass catches
  anything default-mode misses. Defensive — the trace showed events
  arriving fine with default-only polling, but the cost is one extra
  empty-poll per frame and the symmetry with the live-resize fix is
  worth it.

Coordinate conversion: mouse events arrive in logical points, the
canvas is in framebuffer pixels. mouse_to_canvas applies the new
platform_get_dpi_scale() (returns 1.0 if !desc->high_dpi, else
window backingScaleFactor) then subtracts the letterbox offset that
render_paint_mode applies, so the cursor lands exactly on the
painted pixel.

paint_tool / brush_size / painting / last_paint_cx,cy live in
app_state_t — no globals, in line with the no-globals refactor.